### PR TITLE
Fix cosign signing to use bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,8 +53,7 @@ signs:
     args:
       - sign-blob
       - --yes
-      - --output-certificate=${certificate}
-      - --output-signature=${signature}
+      - --bundle=${artifact}.bundle
       - ${artifact}
 
 release:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,10 +50,11 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
+    signature: ${artifact}.bundle
     args:
       - sign-blob
       - --yes
-      - --bundle=${artifact}.bundle
+      - --bundle=${signature}
       - ${artifact}
 
 release:


### PR DESCRIPTION
## Summary

- Fix GoReleaser cosign signing that fails with `--output-signature is deprecated` error
- Switch from deprecated `--output-signature` / `--output-certificate` to `--bundle` format

## Test plan

- [ ] Release workflow completes without cosign errors
- [ ] Bundle file is included in release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)