### PR TITLE
Fix upload-artifact commit hash in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,7 +38,7 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b9c8a4e70792b0a21a7e790 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
## Summary

- Fix incorrect commit hash for `actions/upload-artifact@v4.6.2`
- `...7fa790` → `...7fa02` (typo in hash)

## Test plan

- [ ] Scorecard workflow completes without `Unable to resolve action` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)