### PR TITLE
Improve Signed-Releases scorecard with sigstore and SLSA provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
@@ -42,6 +44,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Run GoReleaser
+        id: run-goreleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           distribution: goreleaser
@@ -51,3 +54,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GLASP_CLIENT_ID: ${{ secrets.GLASP_CLIENT_ID }}
           GLASP_CLIENT_SECRET: ${{ secrets.GLASP_CLIENT_SECRET }}
+
+      - name: Generate SLSA subject hashes
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select(.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
-    signature: ${artifact}.bundle
+    signature: ${artifact}.sigstore.json
     args:
       - sign-blob
       - --yes


### PR DESCRIPTION
## Summary

Scorecard gives 0/10 on Signed-Releases because `.bundle` extension is not recognized.

- Rename cosign output from `.bundle` to `.sigstore.json` (recognized by Scorecard, 8/10)
- Add SLSA provenance job using `slsa-github-generator` to produce `.intoto.jsonl` attestation (10/10)
- GoReleaser job now outputs artifact hashes for the provenance job

### Release workflow flow
1. `goreleaser` job: build binaries, sign checksums with cosign, output hashes
2. `provenance` job: generate SLSA Level 3 provenance attestation, upload to release

## Test plan

- [ ] Next release includes `checksums.txt.sigstore.json` artifact
- [ ] Next release includes `multiple.intoto.jsonl` SLSA provenance artifact
- [ ] Scorecard Signed-Releases score improves from 0 to 8-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)