### PR TITLE
GoReleaser に use_existing_draft を追加 (Immutable Releases 対応)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,7 @@ release:
     name: glasp
   prerelease: auto
   mode: keep-existing
+  use_existing_draft: true
 
 changelog:
   use: github-native


### PR DESCRIPTION
## Summary
- GoReleaser の release 設定に `use_existing_draft: true` を追加
- GitHub Immutable Releases が有効化された場合に、tagpr が作成するドラフトリリースを GoReleaser が再利用できるようにする

## Background
- tagpr は `.tagpr` の `release = "draft"` によりドラフトリリースを作成する
- Immutable Releases が有効だと、公開済みリリースは変更不可になる
- `use_existing_draft: true` がないと GoReleaser が別リリースを作成しようとして失敗する

## Ref
- https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)