### PR TITLE
tagpr で PAT を使用してワークフロートリガーを有効化

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -25,4 +25,4 @@ jobs:
 
       - uses: Songmu/tagpr@b3fb89424646b06c8aa460f50307c60b6a541425 # v1.17.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GLASP_TAGPR_TOKEN }}


### PR DESCRIPTION
## Summary
- tagpr の `GITHUB_TOKEN` を `GLASP_TAGPR_TOKEN` (Fine-Grained PAT) に変更
- tagpr が作成するリリース PR で test.yml 等のステータスチェックが実行されるようにする

## Background
GitHub Actions のセキュリティ制約により、`GITHUB_TOKEN` で作成されたブランチ/PR では他のワークフローがトリガーされない。PR #17 で test.yml が "Expected" のまま実行されずマージがブロックされていた。

## Test plan
- [ ] マージ後、次の tagpr PR で test.yml が自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)