### PR TITLE
GitHub Pages サイトを追加 (Cayman テーマ)

### DIFF
--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.1.1"
+	Version = "v0.2.0"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,19 @@
+title: glasp
+description: A Go CLI tool for managing Google Apps Script projects. Single-binary, high-performance clasp alternative.
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme
+
+url: https://takihito.github.io
+baseurl: /glasp
+
+# Navigation (used in default layout override)
+nav:
+  - title: Home
+    url: /glasp/
+  - title: Installation
+    url: /glasp/installation
+  - title: Usage
+    url: /glasp/usage
+  - title: GitHub
+    url: https://github.com/takihito/glasp

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ glasp pull
 glasp push
 ```
 
-> **Note:** [Releases](https://github.com/takihito/glasp/releases) ページの Pre-built binary には OAuth credentials が埋め込み済みのため、環境変数の設定は不要です。
+> **Note:** [Releases](https://github.com/takihito/glasp/releases) ページの Pre-built binary は必要に応じて環境変数を設定してください。
 
 詳しくは [Installation](installation) と [Usage](usage) をご覧ください。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Home
+---
+
+# glasp
+
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/takihito/glasp/badge)](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp)
+
+**glasp** は Google Apps Script プロジェクトを管理する Go 製 CLI ツールです。
+Node.js ベースの [clasp](https://github.com/google/clasp) をシングルバイナリで置き換え、高速に動作します。
+
+## Features
+
+- **clasp 完全互換** — `.clasp.json`, `.claspignore`, `.clasprc.json` をそのまま利用可能
+- **TypeScript 自動トランスパイル** — push 時に `.ts` ファイルを自動変換
+- **OAuth2 認証** — ローカルコールバックサーバーによるスムーズなログイン
+- **コマンド履歴** — 実行履歴の記録とリプレイ機能
+- **アーカイブ** — push/pull 操作のスナップショット保存
+- **シングルバイナリ** — インストール不要、ダウンロードしてすぐ使える
+
+## Quick Start
+
+```bash
+# インストール
+go install github.com/takihito/glasp/cmd/glasp@latest
+
+# ログイン
+glasp login
+
+# 既存プロジェクトのクローン
+glasp clone <script-id>
+
+# ファイルの取得・反映
+glasp pull
+glasp push
+```
+
+詳しくは [Installation](installation) と [Usage](usage) をご覧ください。
+
+## Supply-Chain Security
+
+glasp はサプライチェーンセキュリティを重視しています。
+
+- リリースバイナリは [cosign](https://github.com/sigstore/cosign) で署名済み
+- [SLSA Level 3](https://slsa.dev/) の来歴証明 (provenance) を付与
+- [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp) でセキュリティスコアを公開
+- 全 GitHub Actions をコミットハッシュで固定

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,10 @@ Node.js ベースの [clasp](https://github.com/google/clasp) をシングルバ
 # インストール
 go install github.com/takihito/glasp/cmd/glasp@latest
 
+# OAuth credentials を設定（go install の場合は必須）
+export GLASP_CLIENT_ID="your-client-id"
+export GLASP_CLIENT_SECRET="your-client-secret"
+
 # ログイン
 glasp login
 
@@ -35,6 +39,8 @@ glasp clone <script-id>
 glasp pull
 glasp push
 ```
+
+> **Note:** [Releases](https://github.com/takihito/glasp/releases) ページの Pre-built binary には OAuth credentials が埋め込み済みのため、環境変数の設定は不要です。
 
 詳しくは [Installation](installation) と [Usage](usage) をご覧ください。
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,68 @@
+---
+layout: default
+title: Installation
+---
+
+# Installation
+
+## go install
+
+```bash
+go install github.com/takihito/glasp/cmd/glasp@latest
+```
+
+> この方法では OAuth credentials が含まれません。`GLASP_CLIENT_ID` と `GLASP_CLIENT_SECRET` 環境変数を設定してください。
+
+## Pre-built binaries
+
+[Releases](https://github.com/takihito/glasp/releases) ページからダウンロードできます。
+リリースバイナリには OAuth credentials が埋め込み済みで、すぐに利用できます。
+
+```bash
+VERSION=0.1.2
+OS=${OS:-darwin}     # darwin, linux, or windows
+ARCH=${ARCH:-arm64}  # arm64 or amd64
+ARTIFACT="glasp_v${VERSION}_${OS}_${ARCH}.tar.gz"
+CHECKSUMS="checksums.txt"
+
+curl -L -o "${ARTIFACT}" \
+  "https://github.com/takihito/glasp/releases/download/v${VERSION}/${ARTIFACT}"
+curl -L -o "${CHECKSUMS}" \
+  "https://github.com/takihito/glasp/releases/download/v${VERSION}/${CHECKSUMS}"
+
+# Verify checksum
+if command -v sha256sum >/dev/null 2>&1; then
+  grep "  ${ARTIFACT}$" "${CHECKSUMS}" | sha256sum -c
+else
+  grep "  ${ARTIFACT}$" "${CHECKSUMS}" | shasum -a 256 -c
+fi
+
+# Install
+sudo tar -xzf "${ARTIFACT}" -C /usr/local/bin glasp
+```
+
+> **Windows:** `.zip` アーカイブをダウンロードしてください。
+
+## Build from source
+
+```bash
+git clone https://github.com/takihito/glasp.git
+cd glasp
+make build    # bin/glasp にビルド
+make install  # グローバルにインストール
+```
+
+## OAuth credentials
+
+| インストール方法 | credentials |
+|-----------------|-------------|
+| Pre-built binaries | 埋め込み済み、そのまま利用可能 |
+| `go install` / ソースビルド | 環境変数で指定が必要 |
+
+```bash
+export GLASP_CLIENT_ID="your-client-id"
+export GLASP_CLIENT_SECRET="your-client-secret"
+```
+
+環境変数は埋め込み credentials より優先されます。
+OAuth credentials の作成は [Google Cloud Console](https://console.cloud.google.com/apis/credentials) からデスクトップアプリケーション用の OAuth 2.0 credentials を作成してください。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,7 @@ make install  # グローバルにインストール
 
 | インストール方法 | credentials |
 |-----------------|-------------|
-| Pre-built binaries | 埋め込み済み、そのまま利用可能 |
+| Pre-built binaries | 埋め込み済み,環境変数で上書き可能 |
 | `go install` / ソースビルド | 環境変数で指定が必要 |
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,118 @@
+---
+layout: default
+title: Usage
+---
+
+# Usage
+
+## Commands
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `login` | | Google アカウントにログイン |
+| `logout` | | Google アカウントからログアウト |
+| `create-script` | `create` | 新しい Apps Script プロジェクトを作成 |
+| `clone` | | 既存の Apps Script プロジェクトをクローン |
+| `pull` | | Apps Script からファイルをダウンロード |
+| `push` | | ファイルを Apps Script にアップロード |
+| `open-script` | `open` | Apps Script プロジェクトをブラウザで開く |
+| `create-deployment` | | デプロイメントを作成 |
+| `update-deployment` | `deploy` | 既存のデプロイメントを更新 |
+| `list-deployments` | | デプロイメント一覧を表示 |
+| `run-function` | | Apps Script 関数をリモート実行 |
+| `convert` | | プロジェクトファイルを変換 (TS ↔ GAS) |
+| `history` | | コマンド実行履歴を表示 |
+| `config init` | | `.glasp/config.json` を作成 |
+| `version` | | バージョンを表示 |
+
+## Push
+
+```bash
+glasp push              # ローカルファイルをプッシュ
+glasp push --force      # .claspignore を無視（.glasp/ は常に除外）
+glasp push --archive    # プッシュしたファイルをアーカイブ
+glasp push --dryrun     # API 呼び出しなしのドライラン
+```
+
+### TypeScript Support
+
+glasp は push 時に `.ts` ファイルを自動検出してトランスパイルします（`.clasp.json` の `fileExtension` 設定に関係なく）。
+
+- `.ts` → esbuild で JavaScript に変換してプッシュ
+- `.js`, `.gs` → そのままプッシュ
+- `.d.ts` → 除外（デプロイ不可）
+
+### History Replay
+
+```bash
+glasp push --history-id <id>          # アーカイブから再プッシュ
+glasp push --history-id <id> --dryrun # ドライランでリプレイ
+```
+
+## Pull
+
+```bash
+glasp pull              # リモートファイルを取得
+glasp pull --archive    # 取得したファイルをアーカイブ
+```
+
+`fileExtension` が `"ts"` の場合、取得時に GAS JavaScript を TypeScript に自動変換します。
+
+## Authentication
+
+認証トークンは `.glasp/access.json` に保存されます（パーミッション `0600`）。
+
+認証ソースの優先順位:
+1. `--auth` フラグ（`.clasprc.json` のパス）
+2. プロジェクトキャッシュ（`.glasp/access.json`）
+3. インタラクティブログイン
+
+### clasp の認証情報を再利用
+
+```bash
+# 既存の clasp credentials を使用
+glasp push --auth ~/.clasprc.json
+glasp pull --auth ~/.clasprc.json
+glasp clone SCRIPT_ID --auth ~/.clasprc.json
+```
+
+clasp から glasp への移行時に、再認証なしですぐに使い始められます。
+
+## Configuration
+
+### .clasp.json
+
+clasp と同じ設定ファイルを利用します:
+
+```json
+{
+  "scriptId": "your-script-id",
+  "rootDir": "src",
+  "fileExtension": "ts"
+}
+```
+
+### .claspignore
+
+gitignore 構文でファイルを除外します。glasp のデフォルト除外:
+
+- `.glasp/` — glasp 内部ディレクトリ（常に除外）
+- `node_modules/` — npm 依存
+
+## Convert
+
+```bash
+glasp convert --gas-to-ts              # GAS JS → TypeScript
+glasp convert --ts-to-gas              # TypeScript → GAS JS
+glasp convert --ts-to-gas src/main.ts  # 特定ファイルのみ変換
+```
+
+## History
+
+```bash
+glasp history                          # 全履歴を表示
+glasp history --limit 10               # 直近10件
+glasp history --status success         # ステータスでフィルタ
+glasp history --command push           # コマンドでフィルタ
+glasp history --order asc              # 昇順（デフォルト: 降順）
+```


### PR DESCRIPTION
## Summary
- Jekyll + Cayman テーマで glasp の紹介サイトを `docs/` に作成
- Markdown ベースで人力更新しやすい構成

## ページ構成
- **index.md** — プロジェクト概要、Features、Quick Start、セキュリティ対策
- **installation.md** — 3つのインストール方法、OAuth credentials の説明
- **usage.md** — 全コマンドリファレンス、設定ファイル、TypeScript サポート

## マージ後の設定
GitHub Pages の Source を **main ブランチ / `docs/` フォルダ** に設定してください:
Settings → Pages → Source → Deploy from a branch → `main` / `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)