### PR TITLE
Fix SLSA provenance: private-repository 誤検知を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,4 @@ jobs:
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
+      private-repository: true


### PR DESCRIPTION
## Summary
- SLSA provenance generator がリポジトリをプライベートと誤検知して停止していた問題を修正
- `private-repository: true` を追加してチェックをバイパス

## Background
Release workflow の provenance ジョブが以下のエラーで失敗:
```
Repository is private. The workflow has halted in order to keep the repository name
from being exposed in the public transparency log.
```
リポジトリは public だが SLSA generator が誤検知。`private-repository: true` は public リポジトリでも安全に設定可能。

## Ref
- 失敗した CI: https://github.com/takihito/glasp/actions/runs/24271892338/job/70878583620

🤖 Generated with [Claude Code](https://claude.com/claude-code)