### PR TITLE
Fix SLSA provenance: タグ参照に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: SLSA reusable workflows require tag refs (not SHA pinning).
+    # See: https://github.com/slsa-framework/slsa-github-generator/issues/722
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       contents: write
     # NOTE: SLSA reusable workflows require tag refs (not SHA pinning).
     # See: https://github.com/slsa-framework/slsa-github-generator/issues/722
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
## Summary
- SLSA reusable workflow の参照を SHA ピンニングからタグ参照 (`@v2.1.0`) に変更

## Background
SLSA generator の reusable workflow は `refs/tags/vX.Y.Z` 形式の ref を要求します。
SHA ピンニング (`@f7dd8c54...`) だと以下のエラーで失敗します:

```
Invalid ref: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a. Expected ref of the form refs/tags/vX.Y.Z
```

これは GitHub reusable workflow の既知の制約で、通常の Actions の SHA ピンニングとは異なります。

## Ref
- 失敗した CI: https://github.com/takihito/glasp/actions/runs/24276431723/job/70891210691

🤖 Generated with [Claude Code](https://claude.com/claude-code)