### PR TITLE
Fix SLSA workflow ref format (@v2.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,8 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    # NOTE: SLSA reusable workflows require tag refs (not SHA pinning).
-    # See: https://github.com/slsa-framework/slsa-github-generator/issues/722
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.1.0
+    # NOTE: SLSA reusable workflows require tag refs, not SHA pinning.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
## Summary
- SLSA reusable workflow の参照を `@refs/tags/v2.1.0` から `@v2.1.0` に修正

## Background
GitHub Actions の `uses` ディレクティブは `refs/tags/` プレフィックスを受け付けない。
現在 main にある `@refs/tags/v2.1.0` は `Invalid workflow file` エラーになる。

正しい形式: `@v2.1.0`（プレーンなタグ名）

🤖 Generated with [Claude Code](https://claude.com/claude-code)