### PR TITLE
Immutable Releases 対応: ドラフト維持 + provenance 後に公開

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,20 @@ jobs:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
       private-repository: true
+      draft-release: true
+
+  publish:
+    needs: [provenance]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --repo "${{ github.repository }}" --draft=false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,6 +64,7 @@ release:
   prerelease: auto
   mode: keep-existing
   use_existing_draft: true
+  draft: true
 
 changelog:
   use: github-native


### PR DESCRIPTION
## Summary
- GoReleaser でリリースをドラフトのまま維持 (`draft: true`)
- SLSA provenance もドラフトに対してアップロード (`draft-release: true`)
- 全アセットアップロード完了後に `publish` ジョブでリリースを公開

## Background
Immutable Releases が有効な環境では、公開済みリリースへのアセット追加が不可。
従来の流れでは GoReleaser がリリースを公開 → SLSA provenance が `.intoto.jsonl` をアップロードできずに失敗していた。

## 新しいフロー
```
tagpr (draft release)
  → goreleaser (upload assets, keep draft)
    → provenance (upload .intoto.jsonl to draft)
      → publish (draft → public)
```

## Ref
- 失敗した CI: https://github.com/takihito/glasp/actions/runs/24278147733
- Immutable Releases: https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)