### PR TITLE
Release for v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.2.4](https://github.com/takihito/glasp/compare/v0.2.3...v0.2.4) - 2026-04-11
+- Immutable Releases 対応: ドラフト維持 + provenance 後に公開 by @takihito in https://github.com/takihito/glasp/pull/33
+
 ## [v0.2.3](https://github.com/takihito/glasp/compare/v0.2.2...v0.2.3) - 2026-04-11
 - Fix SLSA workflow ref format (@v2.1.0) by @takihito in https://github.com/takihito/glasp/pull/31
 

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.3"
+	Version = "v0.2.4"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.2.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Immutable Releases 対応: ドラフト維持 + provenance 後に公開 by @takihito in https://github.com/takihito/glasp/pull/33


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.3...tagpr-from-v0.2.3