### PR TITLE
PATH 設定手順をドキュメントに追記

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,8 @@
 
 Google Apps Script プロジェクトを管理するための Go 製 CLI ツール。Node.js ベースの [clasp](https://github.com/google/clasp) を置き換える、シングルバイナリの高速な代替ツールです。clasp との完全な互換性を備えています。
 
+**ドキュメント:** [https://takihito.github.io/glasp/ja/](https://takihito.github.io/glasp/ja/)
+
 ## 特徴
 
 - clasp 完全互換（`.clasp.json`、`.claspignore`、`.clasprc.json`）

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,11 +30,13 @@ curl -sSL https://takihito.github.io/glasp/install.sh | sh
 irm https://takihito.github.io/glasp/install.ps1 | iex
 ```
 
-デフォルトで `~/.local/bin` にインストールされます。`sudo` は不要です。`~/.local/bin` が PATH に含まれていない場合は、シェルの設定ファイルに追記してください:
+デフォルトで `~/.local/bin` にインストールされます（Linux/macOS）。`sudo` は不要です。`~/.local/bin` が PATH に含まれていない場合は、シェルの設定ファイル（`~/.bashrc`, `~/.zshrc`）に追記してください:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
+
+> **Windows:** PowerShell インストーラーが `%LOCALAPPDATA%\glasp\bin` を PATH に自動追加します。
 
 インストール先を変更する場合:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,7 +28,13 @@ curl -sSL https://takihito.github.io/glasp/install.sh | sh
 irm https://takihito.github.io/glasp/install.ps1 | iex
 ```
 
-デフォルトで `~/.local/bin` にインストールされます。`sudo` は不要です。インストール先を変更する場合:
+デフォルトで `~/.local/bin` にインストールされます。`sudo` は不要です。`~/.local/bin` が PATH に含まれていない場合は、シェルの設定ファイルに追記してください:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+インストール先を変更する場合:
 
 ```bash
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ curl -sSL https://takihito.github.io/glasp/install.sh | sh
 irm https://takihito.github.io/glasp/install.ps1 | iex
 ```
 
-Installs to `~/.local/bin` by default. No `sudo` required. To change the install directory:
+Installs to `~/.local/bin` by default. No `sudo` required. If `~/.local/bin` is not in your PATH, add it to your shell profile:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+To change the install directory:
 
 ```bash
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ curl -sSL https://takihito.github.io/glasp/install.sh | sh
 irm https://takihito.github.io/glasp/install.ps1 | iex
 ```
 
-Installs to `~/.local/bin` by default. No `sudo` required. If `~/.local/bin` is not in your PATH, add it to your shell profile:
+Installs to `~/.local/bin` by default (Linux/macOS). No `sudo` required. If `~/.local/bin` is not in your PATH, add it to your shell profile (`~/.bashrc`, `~/.zshrc`):
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
+
+> **Windows:** The PowerShell installer adds `%LOCALAPPDATA%\glasp\bin` to PATH automatically.
 
 To change the install directory:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Go CLI tool that replaces Node.js-based [clasp](https://github.com/google/clasp) for managing Google Apps Script projects. Single-binary, high-performance alternative with full clasp compatibility.
 
+**Documentation:** [https://takihito.github.io/glasp/](https://takihito.github.io/glasp/)
+
 ## Features
 
 - Full clasp compatibility (`.clasp.json`, `.claspignore`, `.clasprc.json`)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,5 +15,7 @@ nav:
     url: /glasp/installation
   - title: Usage
     url: /glasp/usage
+  - title: 日本語
+    url: /glasp/ja/
   - title: GitHub
     url: https://github.com/takihito/glasp

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,50 +7,52 @@ title: Home
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/takihito/glasp/badge)](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp)
 
-**glasp** は Google Apps Script プロジェクトを管理する Go 製 CLI ツールです。
-Node.js ベースの [clasp](https://github.com/google/clasp) をシングルバイナリで置き換え、高速に動作します。
+**glasp** is a Go CLI tool for managing Google Apps Script projects.
+A single-binary, high-performance replacement for Node.js-based [clasp](https://github.com/google/clasp).
+
+[日本語ドキュメント](ja/)
 
 ## Features
 
-- **clasp 完全互換** — `.clasp.json`, `.claspignore`, `.clasprc.json` をそのまま利用可能
-- **TypeScript 自動トランスパイル** — push 時に `.ts` ファイルを自動変換
-- **OAuth2 認証** — ローカルコールバックサーバーによるスムーズなログイン
-- **コマンド履歴** — 実行履歴の記録とリプレイ機能
-- **アーカイブ** — push/pull 操作のスナップショット保存
-- **シングルバイナリ** — インストール不要、ダウンロードしてすぐ使える
+- **Full clasp compatibility** — works with `.clasp.json`, `.claspignore`, `.clasprc.json`
+- **TypeScript auto-transpilation** — `.ts` files are automatically converted on push
+- **OAuth2 authentication** — smooth login via local callback server
+- **Command history** — execution history with replay support
+- **Archive** — snapshot push/pull operations
+- **Single binary** — download and run, no installation dependencies
 
 ## Quick Start
 
 ```bash
-# インストール（Linux / macOS）
+# Install (Linux / macOS)
 curl -sSL https://takihito.github.io/glasp/install.sh | sh
 
-# ログイン
+# Login
 glasp login
 
-# 既存プロジェクトのクローン
+# Clone an existing project
 glasp clone <script-id>
 
-# ファイルの取得・反映
+# Pull and push files
 glasp pull
 glasp push
 ```
 
-デフォルトでは `~/.local/bin` にインストールされます。変更する場合:
+Installs to `~/.local/bin` by default. To change the install directory:
 
 ```bash
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
 ```
 
-> **Windows:** `irm https://takihito.github.io/glasp/install.ps1 | iex` でインストールできます。
+> **Windows:** `irm https://takihito.github.io/glasp/install.ps1 | iex`
 
-詳しくは [Installation](installation) と [Usage](usage) をご覧ください。
+See [Installation](installation) and [Usage](usage) for details.
 
 ## Supply-Chain Security
 
-glasp はサプライチェーンセキュリティを重視しています。
+glasp takes supply-chain security seriously.
 
-- リリースバイナリは [cosign](https://github.com/sigstore/cosign) で署名済み
-- [SLSA Level 3](https://slsa.dev/) の来歴証明 (provenance) を付与
-- [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp) でセキュリティスコアを公開
-- 全 GitHub Actions をコミットハッシュで固定
+- Release binaries are signed with [cosign](https://github.com/sigstore/cosign)
+- [SLSA Level 3](https://slsa.dev/) provenance attached to releases
+- [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp) published
+- All GitHub Actions pinned to commit SHA

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,12 @@ irm https://takihito.github.io/glasp/install.ps1 | iex
 
 最新バージョンを自動検出し、チェックサム検証後に `~/.local/bin` にインストールします。`sudo` は不要です。
 
+`~/.local/bin` が PATH に含まれていない場合は、シェルの設定ファイル（`~/.bashrc`, `~/.zshrc` 等）に以下を追記してください:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
 インストール先を変更する場合:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,15 +19,15 @@ curl -sSL https://takihito.github.io/glasp/install.sh | sh
 irm https://takihito.github.io/glasp/install.ps1 | iex
 ```
 
-最新バージョンを自動検出し、チェックサム検証後に `~/.local/bin` にインストールします。`sudo` は不要です。
+Automatically detects the latest version, verifies checksums, and installs to `~/.local/bin`. No `sudo` required.
 
-`~/.local/bin` が PATH に含まれていない場合は、シェルの設定ファイル（`~/.bashrc`, `~/.zshrc` 等）に以下を追記してください:
+If `~/.local/bin` is not in your PATH, add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-インストール先を変更する場合:
+To change the install directory:
 
 ```bash
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
@@ -39,32 +39,31 @@ curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/l
 go install github.com/takihito/glasp/cmd/glasp@latest
 ```
 
-> この方法では OAuth credentials が含まれません。`GLASP_CLIENT_ID` と `GLASP_CLIENT_SECRET` 環境変数を設定してください。
+> This method does not embed OAuth credentials. Set `GLASP_CLIENT_ID` and `GLASP_CLIENT_SECRET` environment variables.
 
 ## Pre-built binaries
 
-手動でダウンロードする場合は [Releases](https://github.com/takihito/glasp/releases) ページを参照してください。
+For manual downloads, see the [Releases](https://github.com/takihito/glasp/releases) page.
 
 ## Build from source
 
 ```bash
 git clone https://github.com/takihito/glasp.git
 cd glasp
-make build    # bin/glasp にビルド
-make install  # グローバルにインストール
+make build    # Build binary to bin/glasp
+make install  # Build and install globally
 ```
 
 ## OAuth credentials
 
-| インストール方法 | credentials |
-|-----------------|-------------|
-| Pre-built binaries | 埋め込み済み,環境変数で上書き可能 |
-| `go install` / ソースビルド | 環境変数で指定が必要 |
+| Install method | Credentials |
+|---------------|-------------|
+| Quick Install (pre-built binaries) | Embedded, override with env vars |
+| `go install` / source build | Env vars required |
 
 ```bash
 export GLASP_CLIENT_ID="your-client-id"
 export GLASP_CLIENT_SECRET="your-client-secret"
 ```
 
-環境変数は埋め込み credentials より優先されます。
-OAuth credentials の作成は [Google Cloud Console](https://console.cloud.google.com/apis/credentials) からデスクトップアプリケーション用の OAuth 2.0 credentials を作成してください。
+Environment variables take precedence over embedded credentials. See [Google Cloud Console](https://console.cloud.google.com/apis/credentials) to create OAuth 2.0 credentials for a Desktop application.

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: ホーム
+---
+
+# glasp
+
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/takihito/glasp/badge)](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp)
+
+**glasp** は Google Apps Script プロジェクトを管理する Go 製 CLI ツールです。
+Node.js ベースの [clasp](https://github.com/google/clasp) をシングルバイナリで置き換え、高速に動作します。
+
+[English](../)
+
+## Features
+
+- **clasp 完全互換** — `.clasp.json`, `.claspignore`, `.clasprc.json` をそのまま利用可能
+- **TypeScript 自動トランスパイル** — push 時に `.ts` ファイルを自動変換
+- **OAuth2 認証** — ローカルコールバックサーバーによるスムーズなログイン
+- **コマンド履歴** — 実行履歴の記録とリプレイ機能
+- **アーカイブ** — push/pull 操作のスナップショット保存
+- **シングルバイナリ** — インストール不要、ダウンロードしてすぐ使える
+
+## Quick Start
+
+```bash
+# インストール（Linux / macOS）
+curl -sSL https://takihito.github.io/glasp/install.sh | sh
+
+# ログイン
+glasp login
+
+# 既存プロジェクトのクローン
+glasp clone <script-id>
+
+# ファイルの取得・反映
+glasp pull
+glasp push
+```
+
+デフォルトでは `~/.local/bin` にインストールされます。変更する場合:
+
+```bash
+curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
+```
+
+> **Windows:** `irm https://takihito.github.io/glasp/install.ps1 | iex` でインストールできます。
+
+詳しくは [インストール](installation) と [使い方](usage) をご覧ください。
+
+## Supply-Chain Security
+
+glasp はサプライチェーンセキュリティを重視しています。
+
+- リリースバイナリは [cosign](https://github.com/sigstore/cosign) で署名済み
+- [SLSA Level 3](https://slsa.dev/) の来歴証明 (provenance) を付与
+- [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/takihito/glasp) でセキュリティスコアを公開
+- 全 GitHub Actions をコミットハッシュで固定

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -1,0 +1,69 @@
+---
+layout: default
+title: インストール
+---
+
+# インストール
+
+## クイックインストール（推奨）
+
+**Linux / macOS:**
+
+```bash
+curl -sSL https://takihito.github.io/glasp/install.sh | sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://takihito.github.io/glasp/install.ps1 | iex
+```
+
+最新バージョンを自動検出し、チェックサム検証後に `~/.local/bin` にインストールします。`sudo` は不要です。
+
+`~/.local/bin` が PATH に含まれていない場合は、シェルの設定ファイル（`~/.bashrc`, `~/.zshrc` 等）に以下を追記してください:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+インストール先を変更する場合:
+
+```bash
+curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
+```
+
+## go install
+
+```bash
+go install github.com/takihito/glasp/cmd/glasp@latest
+```
+
+> この方法では OAuth credentials が含まれません。`GLASP_CLIENT_ID` と `GLASP_CLIENT_SECRET` 環境変数を設定してください。
+
+## Pre-built binaries
+
+手動でダウンロードする場合は [Releases](https://github.com/takihito/glasp/releases) ページを参照してください。
+
+## ソースからビルド
+
+```bash
+git clone https://github.com/takihito/glasp.git
+cd glasp
+make build    # bin/glasp にビルド
+make install  # グローバルにインストール
+```
+
+## OAuth credentials
+
+| インストール方法 | credentials |
+|-----------------|-------------|
+| クイックインストール（ビルド済みバイナリ） | 埋め込み済み、環境変数で上書き可能 |
+| `go install` / ソースビルド | 環境変数で指定が必要 |
+
+```bash
+export GLASP_CLIENT_ID="your-client-id"
+export GLASP_CLIENT_SECRET="your-client-secret"
+```
+
+環境変数は埋め込み credentials より優先されます。[Google Cloud Console](https://console.cloud.google.com/apis/credentials) からデスクトップアプリケーション用の OAuth 2.0 credentials を作成してください。

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -1,0 +1,121 @@
+---
+layout: default
+title: 使い方
+---
+
+# 使い方
+
+## コマンド一覧
+
+| コマンド | エイリアス | 説明 |
+|---------|-----------|------|
+| `login` | | Google アカウントにログイン |
+| `logout` | | Google アカウントからログアウト |
+| `create-script` | `create` | 新しい Apps Script プロジェクトを作成 |
+| `clone` | | 既存の Apps Script プロジェクトをクローン |
+| `pull` | | Apps Script からファイルをダウンロード |
+| `push` | | ファイルを Apps Script にアップロード |
+| `open-script` | `open` | Apps Script プロジェクトをブラウザで開く |
+| `create-deployment` | | デプロイメントを作成 |
+| `update-deployment` | `deploy` | 既存のデプロイメントを更新 |
+| `list-deployments` | | デプロイメント一覧を表示 |
+| `run-function` | | Apps Script 関数をリモート実行 |
+| `convert` | | プロジェクトファイルを変換 (TS ↔ GAS) |
+| `history` | | コマンド実行履歴を表示 |
+| `config init` | | `.glasp/config.json` を作成 |
+| `version` | | バージョンを表示 |
+
+## Push
+
+```bash
+glasp push              # ローカルファイルをプッシュ
+glasp push --force      # .claspignore を無視（.glasp/ は常に除外）
+glasp push --archive    # プッシュしたファイルをアーカイブ
+glasp push --dryrun     # API 呼び出しなしのドライラン
+```
+
+### TypeScript サポート
+
+glasp は push 時に `.ts` ファイルを自動検出してトランスパイルします（`.clasp.json` の `fileExtension` 設定に関係なく）。
+
+- `.ts` → esbuild で JavaScript に変換してプッシュ
+- `.js`, `.gs` → そのままプッシュ
+- `.d.ts` → 除外（デプロイ不可）
+
+### 履歴からのリプレイ
+
+```bash
+glasp push --history-id <id>          # アーカイブから再プッシュ
+glasp push --history-id <id> --dryrun # ドライランでリプレイ
+```
+
+## Pull
+
+```bash
+glasp pull              # リモートファイルを取得
+glasp pull --archive    # 取得したファイルをアーカイブ
+```
+
+`fileExtension` が `"ts"` の場合、取得時に GAS JavaScript を TypeScript に自動変換します。
+
+## 認証
+
+認証トークンは `.glasp/access.json` に保存されます（パーミッション `0600`）。
+
+認証ソースの優先順位:
+1. `--auth` フラグ（`.clasprc.json` のパス）
+2. プロジェクトキャッシュ（`.glasp/access.json`）
+3. インタラクティブログイン
+
+### clasp の認証情報を再利用
+
+```bash
+# clasp の認証情報を glasp にインポート
+glasp login --auth ~/.clasprc.json
+
+# または、各コマンドで直接 --auth を指定
+glasp push --auth ~/.clasprc.json
+glasp pull --auth ~/.clasprc.json
+glasp clone SCRIPT_ID --auth ~/.clasprc.json
+```
+
+clasp から glasp への移行時に、再認証なしですぐに使い始められます。
+
+## 設定
+
+### .clasp.json
+
+clasp と同じ設定ファイルを利用します:
+
+```json
+{
+  "scriptId": "your-script-id",
+  "rootDir": "src",
+  "fileExtension": "ts"
+}
+```
+
+### .claspignore
+
+gitignore 構文でファイルを除外します。glasp のデフォルト除外:
+
+- `.glasp/` — glasp 内部ディレクトリ（常に除外）
+- `node_modules/` — npm 依存
+
+## Convert
+
+```bash
+glasp convert --gas-to-ts              # GAS JS → TypeScript
+glasp convert --ts-to-gas              # TypeScript → GAS JS
+glasp convert --ts-to-gas src/main.ts  # 特定ファイルのみ変換
+```
+
+## 履歴
+
+```bash
+glasp history                          # 全履歴を表示
+glasp history --limit 10               # 直近10件
+glasp history --status success         # ステータスでフィルタ
+glasp history --command push           # コマンドでフィルタ
+glasp history --order asc              # 昇順（デフォルト: 降順）
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,80 +9,83 @@ title: Usage
 
 | Command | Alias | Description |
 |---------|-------|-------------|
-| `login` | | Google アカウントにログイン |
-| `logout` | | Google アカウントからログアウト |
-| `create-script` | `create` | 新しい Apps Script プロジェクトを作成 |
-| `clone` | | 既存の Apps Script プロジェクトをクローン |
-| `pull` | | Apps Script からファイルをダウンロード |
-| `push` | | ファイルを Apps Script にアップロード |
-| `open-script` | `open` | Apps Script プロジェクトをブラウザで開く |
-| `create-deployment` | | デプロイメントを作成 |
-| `update-deployment` | `deploy` | 既存のデプロイメントを更新 |
-| `list-deployments` | | デプロイメント一覧を表示 |
-| `run-function` | | Apps Script 関数をリモート実行 |
-| `convert` | | プロジェクトファイルを変換 (TS ↔ GAS) |
-| `history` | | コマンド実行履歴を表示 |
-| `config init` | | `.glasp/config.json` を作成 |
-| `version` | | バージョンを表示 |
+| `login` | | Log in to Google account |
+| `logout` | | Log out from Google account |
+| `create-script` | `create` | Create a new Apps Script project |
+| `clone` | | Clone an existing Apps Script project |
+| `pull` | | Download project files from Apps Script |
+| `push` | | Upload project files to Apps Script |
+| `open-script` | `open` | Open the Apps Script project in browser |
+| `create-deployment` | | Create a deployment |
+| `update-deployment` | `deploy` | Update an existing deployment |
+| `list-deployments` | | List deployments |
+| `run-function` | | Run an Apps Script function remotely |
+| `convert` | | Convert project files (TS ↔ GAS) |
+| `history` | | Show command execution history |
+| `config init` | | Create `.glasp/config.json` |
+| `version` | | Show version |
 
 ## Push
 
 ```bash
-glasp push              # ローカルファイルをプッシュ
-glasp push --force      # .claspignore を無視（.glasp/ は常に除外）
-glasp push --archive    # プッシュしたファイルをアーカイブ
-glasp push --dryrun     # API 呼び出しなしのドライラン
+glasp push              # Push local files
+glasp push --force      # Ignore .claspignore (.glasp/ is always excluded)
+glasp push --archive    # Archive pushed files
+glasp push --dryrun     # Dry run without API calls
 ```
 
 ### TypeScript Support
 
-glasp は push 時に `.ts` ファイルを自動検出してトランスパイルします（`.clasp.json` の `fileExtension` 設定に関係なく）。
+glasp automatically detects and transpiles `.ts` files on push, regardless of `fileExtension` setting in `.clasp.json`.
 
-- `.ts` → esbuild で JavaScript に変換してプッシュ
-- `.js`, `.gs` → そのままプッシュ
-- `.d.ts` → 除外（デプロイ不可）
+- `.ts` → transpiled to JavaScript via esbuild before push
+- `.js`, `.gs` → passed through unchanged
+- `.d.ts` → excluded (not deployable)
 
 ### History Replay
 
 ```bash
-glasp push --history-id <id>          # アーカイブから再プッシュ
-glasp push --history-id <id> --dryrun # ドライランでリプレイ
+glasp push --history-id <id>          # Re-push from archive
+glasp push --history-id <id> --dryrun # Dry run replay
 ```
 
 ## Pull
 
 ```bash
-glasp pull              # リモートファイルを取得
-glasp pull --archive    # 取得したファイルをアーカイブ
+glasp pull              # Pull remote files
+glasp pull --archive    # Archive pulled files
 ```
 
-`fileExtension` が `"ts"` の場合、取得時に GAS JavaScript を TypeScript に自動変換します。
+When `fileExtension` is `"ts"`, pulled files are automatically converted from GAS JavaScript to TypeScript.
 
 ## Authentication
 
-認証トークンは `.glasp/access.json` に保存されます（パーミッション `0600`）。
+Auth tokens are stored at `.glasp/access.json` (permission `0600`).
 
-認証ソースの優先順位:
-1. `--auth` フラグ（`.clasprc.json` のパス）
-2. プロジェクトキャッシュ（`.glasp/access.json`）
-3. インタラクティブログイン
+Auth source priority:
+1. `--auth` flag (path to `.clasprc.json`)
+2. Project cache (`.glasp/access.json`)
+3. Interactive login flow
 
-### clasp の認証情報を再利用
+### Reuse clasp credentials
 
 ```bash
-# 既存の clasp credentials を使用
+# Import clasp credentials into glasp
+glasp login --auth ~/.clasprc.json
+
+# Or use --auth directly on each command
 glasp push --auth ~/.clasprc.json
 glasp pull --auth ~/.clasprc.json
 glasp clone SCRIPT_ID --auth ~/.clasprc.json
 ```
 
-clasp から glasp への移行時に、再認証なしですぐに使い始められます。
+Start using glasp immediately when migrating from clasp — no re-authentication needed.
 
 ## Configuration
 
 ### .clasp.json
 
-clasp と同じ設定ファイルを利用します:
+Standard clasp configuration file. glasp reads the same format:
 
 ```json
 {
@@ -94,25 +97,25 @@ clasp と同じ設定ファイルを利用します:
 
 ### .claspignore
 
-gitignore 構文でファイルを除外します。glasp のデフォルト除外:
+Gitignore syntax for excluding files. glasp default excludes:
 
-- `.glasp/` — glasp 内部ディレクトリ（常に除外）
-- `node_modules/` — npm 依存
+- `.glasp/` — glasp internal directory (always excluded)
+- `node_modules/` — npm dependencies
 
 ## Convert
 
 ```bash
 glasp convert --gas-to-ts              # GAS JS → TypeScript
 glasp convert --ts-to-gas              # TypeScript → GAS JS
-glasp convert --ts-to-gas src/main.ts  # 特定ファイルのみ変換
+glasp convert --ts-to-gas src/main.ts  # Convert specific files
 ```
 
 ## History
 
 ```bash
-glasp history                          # 全履歴を表示
-glasp history --limit 10               # 直近10件
-glasp history --status success         # ステータスでフィルタ
-glasp history --command push           # コマンドでフィルタ
-glasp history --order asc              # 昇順（デフォルト: 降順）
+glasp history                          # Show all history
+glasp history --limit 10               # Last 10 entries
+glasp history --status success         # Filter by status
+glasp history --command push           # Filter by command
+glasp history --order asc              # Oldest first (default: desc)
 ```


### PR DESCRIPTION
## Summary
- Quick Install 後に `~/.local/bin` を PATH に追加する手順を追記
- README.md, README.ja.md, docs/installation.md の3箇所に追加

## Background
Quick Install はデフォルトで `~/.local/bin` にインストールするが、多くの環境でこのディレクトリが PATH に含まれていない。インストール後に `glasp: command not found` になるケースを防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)