### PR TITLE
Release for v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.2.7](https://github.com/takihito/glasp/compare/v0.2.6...v0.2.7) - 2026-04-16
+- Bump google.golang.org/api from 0.274.0 to 0.275.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/40
+- Bump Songmu/tagpr from 1.17.1 to 1.18.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/41
+- Bump golang.org/x/sys from 0.42.0 to 0.43.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/42
+- Bump actions/upload-artifact from 4.6.2 to 7.0.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/43
+- Bump step-security/harden-runner from 2.16.1 to 2.17.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/44
+- feat: GitHub Actions support (action.yml + GLASP_AUTH env var) by @takihito in https://github.com/takihito/glasp/pull/47
+- fix: remove expression syntax from action.yml description field by @takihito in https://github.com/takihito/glasp/pull/48
+
 ## [v0.2.6](https://github.com/takihito/glasp/compare/v0.2.5...v0.2.6) - 2026-04-12
 - updare Readme and docs by @takihito in https://github.com/takihito/glasp/pull/37
 

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.6"
+	Version = "v0.2.7"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.2.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump google.golang.org/api from 0.274.0 to 0.275.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/40
* Bump Songmu/tagpr from 1.17.1 to 1.18.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/41
* Bump golang.org/x/sys from 0.42.0 to 0.43.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/42
* Bump actions/upload-artifact from 4.6.2 to 7.0.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/43
* Bump step-security/harden-runner from 2.16.1 to 2.17.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/44
* feat: GitHub Actions support (action.yml + GLASP_AUTH env var) by @takihito in https://github.com/takihito/glasp/pull/47
* fix: remove expression syntax from action.yml description field by @takihito in https://github.com/takihito/glasp/pull/48


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.6...tagpr-from-v0.2.6