### PR TITLE
fix: remove expression syntax from action.yml description field

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,10 @@ inputs:
   auth:
     description: |
       JSON content of .clasprc.json for authentication.
-      Store this value as a repository secret and pass it as:
-        auth: ${{ secrets.GLASP_AUTH }}
-      When provided, the value is exported as the GLASP_AUTH environment variable
-      so that subsequent glasp commands authenticate without a --auth flag.
+      Store this value as a repository secret (e.g. GLASP_AUTH) and reference it
+      via secrets.GLASP_AUTH in your workflow. When provided, the value is
+      exported as the GLASP_AUTH environment variable so that subsequent glasp
+      commands authenticate without a --auth flag.
     required: false
     default: ''
   working-directory:


### PR DESCRIPTION
## Summary

Fixes a `TemplateValidationException` that occurred when calling the action from a GitHub Actions workflow.

### Root cause

`${{ secrets.GLASP_AUTH }}` written in the `auth` input `description` block was parsed as a GitHub Actions template expression. The `secrets` context is not available during action definition parsing, causing:

```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GLASP_AUTH
```

### Fix

Replaced the expression syntax in the `description` field with plain text (`secrets.GLASP_AUTH`). The description is documentation only and does not need expression evaluation.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [ ] Action invoked from a workflow without `TemplateValidationException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)