### PR TITLE
Release for v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.2.8](https://github.com/takihito/glasp/compare/v0.2.7...v0.2.8) - 2026-04-20
+- feat: add client-id and client-secret inputs to action.yml by @takihito in https://github.com/takihito/glasp/pull/50
+- docs: sync EN docs with updated JA docs and README.ja.md by @takihito in https://github.com/takihito/glasp/pull/52
+
 ## [v0.2.7](https://github.com/takihito/glasp/compare/v0.2.6...v0.2.7) - 2026-04-16
 - Bump google.golang.org/api from 0.274.0 to 0.275.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/40
 - Bump Songmu/tagpr from 1.17.1 to 1.18.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/41

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.7"
+	Version = "v0.2.8"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.2.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: add client-id and client-secret inputs to action.yml by @takihito in https://github.com/takihito/glasp/pull/50
* docs: sync EN docs with updated JA docs and README.ja.md by @takihito in https://github.com/takihito/glasp/pull/52


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.7...tagpr-from-v0.2.7