### PR TITLE
Release for v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.2.9](https://github.com/takihito/glasp/compare/v0.2.8...v0.2.9) - 2026-04-21
+- update README, docs/github-actions.md by @takihito in https://github.com/takihito/glasp/pull/53
+- docs _config.yml render_with_liquid: false by @takihito in https://github.com/takihito/glasp/pull/60
+- build(deps): bump google.golang.org/api from 0.275.0 to 0.276.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/56
+- build(deps): bump github/codeql-action from 4.35.1 to 4.35.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/55
+- build(deps): bump step-security/harden-runner from 2.17.0 to 2.19.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/57
+- added raw tag. change remote_theme by @takihito in https://github.com/takihito/glasp/pull/61
+- build(deps): bump goreleaser/goreleaser-action from 7.0.0 to 7.1.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/58
+- build(deps): bump Songmu/tagpr from 1.18.2 to 1.18.3 by @dependabot[bot] in https://github.com/takihito/glasp/pull/59
+
 ## [v0.2.8](https://github.com/takihito/glasp/compare/v0.2.7...v0.2.8) - 2026-04-20
 - feat: add client-id and client-secret inputs to action.yml by @takihito in https://github.com/takihito/glasp/pull/50
 - docs: sync EN docs with updated JA docs and README.ja.md by @takihito in https://github.com/takihito/glasp/pull/52

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.8"
+	Version = "v0.2.9"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.2.9 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.9 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update README, docs/github-actions.md by @takihito in https://github.com/takihito/glasp/pull/53
* docs _config.yml render_with_liquid: false by @takihito in https://github.com/takihito/glasp/pull/60
* build(deps): bump google.golang.org/api from 0.275.0 to 0.276.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/56
* build(deps): bump github/codeql-action from 4.35.1 to 4.35.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/55
* build(deps): bump step-security/harden-runner from 2.17.0 to 2.19.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/57
* added raw tag. change remote_theme by @takihito in https://github.com/takihito/glasp/pull/61
* build(deps): bump goreleaser/goreleaser-action from 7.0.0 to 7.1.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/58
* build(deps): bump Songmu/tagpr from 1.18.2 to 1.18.3 by @dependabot[bot] in https://github.com/takihito/glasp/pull/59


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.8...tagpr-from-v0.2.8