### PR TITLE
Release for v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.2.10](https://github.com/takihito/glasp/compare/v0.2.9...v0.2.10) - 2026-05-19
+- build(deps): bump goreleaser/goreleaser-action from 7.1.0 to 7.2.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/62
+- docs: add glasp vs clasp CI benchmark results to GitHub Actions docs by @takihito in https://github.com/takihito/glasp/pull/64
+- docs: use comparison framing in CI benchmark section by @takihito in https://github.com/takihito/glasp/pull/68
+- build(deps): bump github/codeql-action from 4.35.2 to 4.35.3 by @dependabot[bot] in https://github.com/takihito/glasp/pull/65
+- build(deps): bump google.golang.org/api from 0.276.0 to 0.277.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/66
+- build(deps): bump step-security/harden-runner from 2.19.0 to 2.19.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/67
+- add pin to documents by @takihito in https://github.com/takihito/glasp/pull/69
+- build(deps): bump google.golang.org/api from 0.277.0 to 0.278.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/70
+- build(deps): bump golang.org/x/sys from 0.43.0 to 0.44.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/71
+- build(deps): bump github/codeql-action from 4.35.3 to 4.35.4 by @dependabot[bot] in https://github.com/takihito/glasp/pull/72
+- build(deps): bump Songmu/tagpr from 1.18.3 to 1.19.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/74
+- build(deps): bump actions/dependency-review-action from 4.9.0 to 5.0.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/73
+- build(deps): bump sigstore/cosign-installer from 4.1.1 to 4.1.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/75
+- build(deps): bump google.golang.org/api from 0.278.0 to 0.279.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/76
+- build(deps): bump github/codeql-action from 4.35.4 to 4.35.5 by @dependabot[bot] in https://github.com/takihito/glasp/pull/77
+- build(deps): bump step-security/harden-runner from 2.19.1 to 2.19.3 by @dependabot[bot] in https://github.com/takihito/glasp/pull/78
+
 ## [v0.2.9](https://github.com/takihito/glasp/compare/v0.2.8...v0.2.9) - 2026-04-21
 - update README, docs/github-actions.md by @takihito in https://github.com/takihito/glasp/pull/53
 - docs _config.yml render_with_liquid: false by @takihito in https://github.com/takihito/glasp/pull/60

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.9"
+	Version = "v0.2.10"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.2.10 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.10 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.9" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump goreleaser/goreleaser-action from 7.1.0 to 7.2.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/62
* docs: add glasp vs clasp CI benchmark results to GitHub Actions docs by @takihito in https://github.com/takihito/glasp/pull/64
* docs: use comparison framing in CI benchmark section by @takihito in https://github.com/takihito/glasp/pull/68
* build(deps): bump github/codeql-action from 4.35.2 to 4.35.3 by @dependabot[bot] in https://github.com/takihito/glasp/pull/65
* build(deps): bump google.golang.org/api from 0.276.0 to 0.277.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/66
* build(deps): bump step-security/harden-runner from 2.19.0 to 2.19.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/67
* add pin to documents by @takihito in https://github.com/takihito/glasp/pull/69
* build(deps): bump google.golang.org/api from 0.277.0 to 0.278.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/70
* build(deps): bump golang.org/x/sys from 0.43.0 to 0.44.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/71
* build(deps): bump github/codeql-action from 4.35.3 to 4.35.4 by @dependabot[bot] in https://github.com/takihito/glasp/pull/72
* build(deps): bump Songmu/tagpr from 1.18.3 to 1.19.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/74
* build(deps): bump actions/dependency-review-action from 4.9.0 to 5.0.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/73
* build(deps): bump sigstore/cosign-installer from 4.1.1 to 4.1.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/75
* build(deps): bump google.golang.org/api from 0.278.0 to 0.279.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/76
* build(deps): bump github/codeql-action from 4.35.4 to 4.35.5 by @dependabot[bot] in https://github.com/takihito/glasp/pull/77
* build(deps): bump step-security/harden-runner from 2.19.1 to 2.19.3 by @dependabot[bot] in https://github.com/takihito/glasp/pull/78


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.9...tagpr-from-v0.2.9