### PR TITLE
docs: use comparison framing in CI benchmark section

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -8,11 +8,11 @@ description: Using glasp in GitHub Actions workflows to automate Google Apps Scr
 
 glasp provides a composite action that lets you install glasp and authenticate directly inside a GitHub Actions workflow — no manual binary download or login steps required.
 
-## Performance: glasp vs clasp in CI
+## Performance comparison: glasp and clasp in CI
 
 Because glasp is a single precompiled Go binary, setup in GitHub Actions is dramatically faster than installing clasp via npm. The table below shows benchmark results measured on `ubuntu-latest` (glasp v0.2.9 / @google/clasp 3.3.0, push/pull averaged over 5 runs):
 
-| Metric | glasp | clasp | glasp Speed Advantage |
+| Metric | glasp | clasp | Ratio (glasp / clasp) |
 |:-------|------:|------:|:---------------------:|
 | Setup Time | 1337ms | 19150ms | **14.3x** |
 | Push Time (avg) | 1015ms | 1229ms | **1.2x** |

--- a/docs/ja/github-actions.md
+++ b/docs/ja/github-actions.md
@@ -8,11 +8,11 @@ description: GitHub Actions ワークフローで glasp を使って Google Apps
 
 glasp は Composite Action を提供しており、GitHub Actions ワークフローの中で glasp のインストールと認証をまとめて行えます。バイナリの手動ダウンロードや `glasp login` の実行は不要です。
 
-## パフォーマンス: glasp vs clasp in CI
+## パフォーマンス比較: glasp と clasp
 
 glasp はシングルバイナリの Go 製ツールであるため、GitHub Actions でのセットアップ時間が npm 経由で clasp をインストールする場合と比べて大幅に短縮されます。以下は `ubuntu-latest` 上で計測したベンチマーク結果です（glasp v0.2.9 / @google/clasp 3.3.0、push/pull は 5 回平均）。
 
-| 指標 | glasp | clasp | glasp の速度優位 |
+| 指標 | glasp | clasp | 速度比（glasp / clasp）|
 |:----|------:|------:|:--------------:|
 | セットアップ時間 | 1337ms | 19150ms | **14.3x** |
 | Push 時間（平均） | 1015ms | 1229ms | **1.2x** |


### PR DESCRIPTION
## Summary

- ベンチマークセクションの「対決」的な表現を「比較」表現に統一（EN/JA）
  - セクション名: `glasp vs clasp in CI` → `Performance comparison: glasp and clasp in CI`
  - テーブルヘッダー: `glasp Speed Advantage` → `Ratio (glasp / clasp)`
  - JA セクション名: `パフォーマンス: glasp vs clasp in CI` → `パフォーマンス比較: glasp と clasp`
  - JA テーブルヘッダー: `glasp の速度優位` → `速度比（glasp / clasp）`

## Test plan

- [ ] `docs/github-actions.md` のベンチマークセクション見出し・テーブルヘッダーが比較表現になっていること
- [ ] `docs/ja/github-actions.md` の日本語版も同様であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)