### PR TITLE
Release for v0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.2.11](https://github.com/takihito/glasp/compare/v0.2.10...v0.2.11) - 2026-05-27
+- update documents. v0.2.9 -> v0.2.10 by @takihito in https://github.com/takihito/glasp/pull/79
+- build(deps): bump google.golang.org/api from 0.279.0 to 0.280.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/83
+- build(deps): bump step-security/harden-runner from 2.19.3 to 2.19.4 by @dependabot[bot] in https://github.com/takihito/glasp/pull/84
+- build(deps): bump goreleaser/goreleaser-action from 7.2.1 to 7.2.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/86
+- build(deps): bump golang.org/x/sys from 0.44.0 to 0.45.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/85
+- build(deps): bump github/codeql-action from 4.35.5 to 4.36.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/87
+- deps: bump golang.org/x/crypto to v0.52.0 by @takihito in https://github.com/takihito/glasp/pull/88
+- deps: bump golang.org/x/net to v0.55.0 by @takihito in https://github.com/takihito/glasp/pull/89
+- Harden CI workflows: switch harden-runner to block mode by @takihito in https://github.com/takihito/glasp/pull/82
+- add allowed endpoints. tagpr.yml by @takihito in https://github.com/takihito/glasp/pull/90
+
 ## [v0.2.10](https://github.com/takihito/glasp/compare/v0.2.9...v0.2.10) - 2026-05-19
 - build(deps): bump goreleaser/goreleaser-action from 7.1.0 to 7.2.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/62
 - docs: add glasp vs clasp CI benchmark results to GitHub Actions docs by @takihito in https://github.com/takihito/glasp/pull/64

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.10"
+	Version = "v0.2.11"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.2.11 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.11 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.10" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update documents. v0.2.9 -> v0.2.10 by @takihito in https://github.com/takihito/glasp/pull/79
* build(deps): bump google.golang.org/api from 0.279.0 to 0.280.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/83
* build(deps): bump step-security/harden-runner from 2.19.3 to 2.19.4 by @dependabot[bot] in https://github.com/takihito/glasp/pull/84
* build(deps): bump goreleaser/goreleaser-action from 7.2.1 to 7.2.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/86
* build(deps): bump golang.org/x/sys from 0.44.0 to 0.45.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/85
* build(deps): bump github/codeql-action from 4.35.5 to 4.36.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/87
* deps: bump golang.org/x/crypto to v0.52.0 by @takihito in https://github.com/takihito/glasp/pull/88
* deps: bump golang.org/x/net to v0.55.0 by @takihito in https://github.com/takihito/glasp/pull/89
* Harden CI workflows: switch harden-runner to block mode by @takihito in https://github.com/takihito/glasp/pull/82
* add allowed endpoints. tagpr.yml by @takihito in https://github.com/takihito/glasp/pull/90


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.10...tagpr-from-v0.2.10