### PR TITLE
Harden CI workflows: switch harden-runner to block mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,16 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            uploads.github.com:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
             uploads.github.com:443

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            github.com:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,19 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            rekor.sigstore.dev:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            tuf-repo-cdn.sigstore.dev:443
+            uploads.github.com:443
 
       - name: Verify OAuth secrets are configured
         run: |
@@ -87,7 +99,9 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: Publish release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             rekor.sigstore.dev:443
             storage.googleapis.com:443
             sum.golang.org:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,19 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            uploads.github.com:443
+            www.bestpractices.dev:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,15 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.ja.md
+++ b/README.ja.md
@@ -314,6 +314,41 @@ steps:
 
 デプロイメント作成や TypeScript プロジェクトを含む詳細な使用例は [GitHub Actions ドキュメント](https://takihito.github.io/glasp/ja/github-actions) を参照してください。
 
+### step-security/harden-runner で egress を制限する
+
+ワークフローで glasp を実行する際、[`step-security/harden-runner`](https://github.com/step-security/harden-runner) を `block` モードで併用すると、glasp が実際に通信する宛先のみに egress を制限できます：
+
+```yaml
+steps:
+  - name: Harden the runner
+    uses: step-security/harden-runner@v2
+    with:
+      egress-policy: block
+      allowed-endpoints: >
+        api.github.com:443
+        github.com:443
+        objects.githubusercontent.com:443
+        script.googleapis.com:443
+        www.googleapis.com:443
+        oauth2.googleapis.com:443
+
+  - uses: actions/checkout@v4
+  - uses: takihito/glasp@v0.2.10
+    with:
+      auth: ${{ secrets.GLASP_AUTH }}
+  - run: glasp push
+```
+
+エンドポイント一覧：
+
+| Endpoint | 用途 |
+| --- | --- |
+| `api.github.com:443` | アクションインストーラが最新リリース情報を取得 |
+| `github.com:443`, `objects.githubusercontent.com:443` | glasp バイナリのダウンロード |
+| `script.googleapis.com:443` | Apps Script API（`push`、`pull`、デプロイメント、`run-function`） |
+| `www.googleapis.com:443` | プロジェクト作成・clone 時の Drive スコープ |
+| `oauth2.googleapis.com:443` | OAuth アクセストークンのリフレッシュ |
+
 ## 開発
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -314,6 +314,41 @@ If `.clasp.json` is in a subdirectory, use the `working-directory` input (sets `
 
 See the [GitHub Actions documentation](https://takihito.github.io/glasp/github-actions) for full examples including deployments and TypeScript projects.
 
+### Hardening egress with step-security/harden-runner
+
+When running glasp inside a workflow, pair it with [`step-security/harden-runner`](https://github.com/step-security/harden-runner) in `block` mode to restrict outbound traffic to only the endpoints glasp actually needs:
+
+```yaml
+steps:
+  - name: Harden the runner
+    uses: step-security/harden-runner@v2
+    with:
+      egress-policy: block
+      allowed-endpoints: >
+        api.github.com:443
+        github.com:443
+        objects.githubusercontent.com:443
+        script.googleapis.com:443
+        www.googleapis.com:443
+        oauth2.googleapis.com:443
+
+  - uses: actions/checkout@v4
+  - uses: takihito/glasp@v0.2.10
+    with:
+      auth: ${{ secrets.GLASP_AUTH }}
+  - run: glasp push
+```
+
+Endpoint reference:
+
+| Endpoint | Why glasp needs it |
+| --- | --- |
+| `api.github.com:443` | The action installer queries the latest release metadata. |
+| `github.com:443`, `objects.githubusercontent.com:443` | Downloading the released `glasp` binary. |
+| `script.googleapis.com:443` | Apps Script API (`push`, `pull`, deployments, `run-function`). |
+| `www.googleapis.com:443` | Drive scope used during project creation/clone. |
+| `oauth2.googleapis.com:443` | Refreshing the OAuth access token. |
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

Move every `step-security/harden-runner` invocation from `egress-policy: audit` to `egress-policy: block` with an explicit `allowed-endpoints` allowlist tuned per workflow. Also document the recommended `block`-mode snippet for consumers of the `takihito/glasp` GitHub Action.

The harden-runner action is already pinned to `ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3` in every workflow — only the policy is changing.

## Commits

1. `eec57fd` docs: add harden-runner block-mode example for glasp action consumers (English README)
2. `3024dea` docs(ja): same for Japanese README
3. `e0525cd` ci(dependency-review): block mode — `api.github.com`
4. `cca367e` ci(test): block mode — GitHub + Go module endpoints
5. `9f41e11` ci(codeql): block mode — Go modules + CodeQL bundle + GitHub uploads
6. `1182fda` ci(scorecard): block mode — OSV / scorecard.dev / sigstore / GitHub
7. `8bd8622` ci(tagpr): block mode — `api.github.com`, `github.com`
8. `08af28b` ci(release): block mode — Go modules + sigstore (fulcio/rekor/tuf) + GitHub uploads; the `publish` job stays at `api.github.com` only

## Allowed endpoints per workflow

| Workflow | Allowed endpoints |
| --- | --- |
| `dependency-review.yml` | `api.github.com` |
| `test.yml` | GitHub API + releases + `proxy.golang.org`, `sum.golang.org`, `storage.googleapis.com`, `raw.githubusercontent.com` |
| `codeql.yml` | same as test + `uploads.github.com` (SARIF) |
| `scorecard.yml` | `api.osv.dev`, `api.scorecard.dev`, `api.securityscorecards.dev`, `www.bestpractices.dev`, `oss-fuzz-build-logs.storage.googleapis.com`, sigstore (fulcio/rekor/tuf), GitHub API + `uploads.github.com` |
| `tagpr.yml` | `api.github.com`, `github.com` |
| `release.yml` (goreleaser) | GitHub + Go modules + sigstore (fulcio/rekor/tuf) |
| `release.yml` (publish) | `api.github.com` |

## Action consumer docs

The new README section gives users a copy-paste-ready snippet:

```yaml
- uses: step-security/harden-runner@v2
  with:
    egress-policy: block
    allowed-endpoints: >
      api.github.com:443
      github.com:443
      objects.githubusercontent.com:443
      script.googleapis.com:443
      www.googleapis.com:443
      oauth2.googleapis.com:443
- uses: takihito/glasp@v0.2.10
```

with a table explaining why each endpoint is needed (release metadata, binary download, Apps Script API, Drive scope, OAuth token refresh).

## Risk and rollout

The allowlists are derived from each action's typical egress and the goreleaser/cosign configuration, **not from observed audit logs**. If a workflow fails because of an unlisted endpoint, the fix is to add it to `allowed-endpoints` and re-push.

Order of concern (least → most risky):

- `dependency-review` / `test` — runs on every PR, fix surface is immediate
- `codeql` / `scorecard` — failures only impact security reporting
- `tagpr` — uses `GLASP_TAGPR_TOKEN` PAT, blast radius is tag-PR creation
- `release` — sigstore-signed release; consider a `workflow_dispatch` dry-run before tagging if you want extra safety

## Test plan

- [ ] PR CI runs (test, dependency-review, codeql) pass with block mode
- [ ] Schedule-run of scorecard succeeds (or manual dispatch on `main` after merge)
- [ ] Next tag push exercises release.yml end-to-end (sigstore signing + GoReleaser upload)
- [ ] Verify harden-runner insights page shows no policy violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
