### PR TITLE
ci(release): allow timestamp.sigstore.dev for cosign signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
             rekor.sigstore.dev:443
             storage.googleapis.com:443
             sum.golang.org:443
+            timestamp.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443
             timestamp.sigstore.dev:443


### PR DESCRIPTION
## Summary

Add `timestamp.sigstore.dev:443` to the `goreleaser` job's harden-runner `allowed-endpoints`.

## Why

The v0.2.11 release failed during cosign signing:

```
Error: signing dist/checksums.txt: signing bundle: error signing bundle:
Post "https://timestamp.sigstore.dev/api/v1/timestamp": dial tcp 54.185.253.63:443: connect: connection refused
```

`.goreleaser.yaml` signs `checksums.txt` into a `.sigstore.json` bundle (`--bundle`). cosign v2 attaches an RFC 3161 trusted timestamp from `timestamp.sigstore.dev` to that bundle, but the block-mode allowlist only listed the other three sigstore endpoints (`fulcio`, `rekor`, `tuf-repo-cdn`), so the timestamp request was refused.

## Change

```diff
             rekor.sigstore.dev:443
             storage.googleapis.com:443
             sum.golang.org:443
+            timestamp.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
```

## Test plan

- [ ] Re-run the release (re-push tag `v0.2.11` or trigger via `workflow_dispatch`) and confirm cosign signing completes
- [ ] Verify harden-runner insights show no further blocked sigstore endpoints

## Note

This only affects the release workflow (tag push). The failed v0.2.11 release must be re-run after merge to publish signed artifacts.
