### PR TITLE
bump version to v0.3.0

### DIFF
--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -2,7 +2,7 @@ package main
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.2.12"
+	Version = "v0.3.0"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
## Summary

- Bump `Version` in `cmd/glasp/version.go` from `v0.2.12` to `v0.3.0`
- Promotes the next release to the **v0.3.x** series instead of the default patch bump (`v0.2.13`)

## How this drives the next release

`.tagpr` is configured with `versionFile = "cmd/glasp/version.go"`. tagpr reads this file when computing the next version, so seeding it to `v0.3.0` makes the next tagpr release PR target `v0.3.0`.

## Diff

```
cmd/glasp/version.go | 2 +-
```

## Test plan

- [x] `go build ./...` passes
- [ ] After merge, confirm tagpr's release PR proposes `v0.3.0`
- [ ] Merging that release PR tags `v0.3.0`

## Note

This is the "edit versionFile" approach. The next tagpr release PR / CHANGELOG should reflect v0.3.0 after this merges.
