### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.3.0](https://github.com/takihito/glasp/compare/v0.2.12...v0.3.0) - 2026-06-02
+- bump version to v0.3.0 by @takihito in https://github.com/takihito/glasp/pull/94
+- implement OAuth PKCE by @takihito in https://github.com/takihito/glasp/pull/81
+- add glasp smoke test workflow by @takihito in https://github.com/takihito/glasp/pull/96
+- docs: add PKCE documentation and enable smoke test on push by @takihito in https://github.com/takihito/glasp/pull/97
+
 ## [v0.2.12](https://github.com/takihito/glasp/compare/v0.2.11...v0.2.12) - 2026-05-27
 - add alllow endpoint .github/workflows/release.yml by @takihito in https://github.com/takihito/glasp/pull/91
 


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.12" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* bump version to v0.3.0 by @takihito in https://github.com/takihito/glasp/pull/94
* implement OAuth PKCE by @takihito in https://github.com/takihito/glasp/pull/81
* add glasp smoke test workflow by @takihito in https://github.com/takihito/glasp/pull/96
* docs: add PKCE documentation and enable smoke test on push by @takihito in https://github.com/takihito/glasp/pull/97


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.2.12...tagpr-from-v0.2.12