### PR TITLE
add glasp smoke test workflow

### DIFF
--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -3,7 +3,8 @@ name: glasp smoke test
 on:
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: glasp-smoke
@@ -27,6 +28,20 @@ jobs:
             script.googleapis.com:443
             www.googleapis.com:443
             oauth2.googleapis.com:443
+
+      - name: Verify required secrets are configured
+        env:
+          _AUTH: ${{ secrets.GLASP_AUTH }}
+          _SCRIPT_ID: ${{ secrets.GLASP_SMOKE_SCRIPT_ID }}
+        run: |
+          if [ -z "$_AUTH" ]; then
+            echo "::error::GLASP_AUTH must be set as a repository secret."
+            exit 1
+          fi
+          if [ -z "$_SCRIPT_ID" ]; then
+            echo "::error::GLASP_SMOKE_SCRIPT_ID must be set as a repository secret."
+            exit 1
+          fi
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install glasp
         uses: ./

--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -1,0 +1,58 @@
+name: glasp smoke test
+
+on:
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: glasp-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      SCRIPT_ID: ${{ secrets.GLASP_SMOKE_SCRIPT_ID }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            script.googleapis.com:443
+            www.googleapis.com:443
+            oauth2.googleapis.com:443
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install glasp
+        uses: ./
+        with:
+          auth: ${{ secrets.GLASP_AUTH }}
+          client-id: ${{ secrets.GLASP_CLIENT_ID }}
+          client-secret: ${{ secrets.GLASP_CLIENT_SECRET }}
+
+      - name: Prepare workspace
+        id: workspace
+        run: |
+          set -euo pipefail
+          dir="$(mktemp -d "${RUNNER_TEMP}/glasp-smoke.XXXXXX")"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: glasp clone
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp clone "$SCRIPT_ID"
+
+      - name: glasp pull
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp pull
+
+      - name: glasp push
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp push


### PR DESCRIPTION
## Summary

GitHub Actions 上で glasp が end-to-end で動作することを確認する smoke test ワークフローを追加します。

- `workflow_dispatch` のみのトリガー（手動実行）
- `${RUNNER_TEMP}` 配下の一時ディレクトリで `glasp clone → pull → push` を実行
- 対象 GAS の Script ID は `secrets.GLASP_SMOKE_SCRIPT_ID` から取得
- クローン物はランナー破棄と同時に消える（リポジトリへのコミット/PR は発生しない）
- `step-security/harden-runner` を `block` モードで設定し、installer + Google API に必要なエンドポイントのみ許可
- `concurrency` group で同時実行をシリアライズ

## 設計判断

| 項目 | 採用 | 別案 |
| --- | --- | --- |
| `permissions` | `read-all`（既存 `release.yml` と一貫） | 最小化なら `contents: read` |
| 一時ディレクトリのクリーンアップ | 明示削除なし（VM ごと破棄される） | `if: always()` で `rm -rf` も可 |
| `glasp push` | 実 push（要件） | 副作用回避なら `--dryrun` |
| action ref | `uses: ./`（同一リポジトリ内） | 他リポジトリからは `takihito/glasp@<sha>` |
| `version:` 入力 | 省略（最新リリース取得） | 再現性重視なら `version: 'vX.Y.Z'` |

## 前提シークレット

- `GLASP_AUTH`（必須）— `.clasprc.json` または `.glasp/access.json` の中身
- `GLASP_SMOKE_SCRIPT_ID`（必須）— 検証対象 GAS の scriptId
- `GLASP_CLIENT_ID` / `GLASP_CLIENT_SECRET`（任意）— バイナリに埋め込み済みなら不要

## Test plan

- [ ] Actions タブから手動で workflow を起動し、`clone → pull → push` 各ステップが成功すること
- [ ] harden-runner の Post ステップで `Disallowed`/`blocked` の記録がないこと
- [ ] 対象 GAS のリビジョン履歴に push 由来の更新が記録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
