### PR TITLE
docs: add PKCE documentation and enable smoke test on push

### DIFF
--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -1,6 +1,9 @@
 name: glasp smoke test
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -67,6 +67,19 @@ glasp pull --archive    # 取得したファイルをアーカイブ
 2. プロジェクトキャッシュ（`.glasp/access.json`）
 3. インタラクティブログイン
 
+### PKCE
+
+OAuth2 認可コードの横取り攻撃を防ぐ PKCE（RFC 7636）をオプトインで有効化できます：
+
+```bash
+glasp login --pkce
+
+# または環境変数で有効化
+GLASP_USE_PKCE=1 glasp login
+```
+
+PKCE は `glasp login` フローにのみ適用されます。
+
 ### clasp の認証情報を再利用
 
 ```bash

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -69,7 +69,7 @@ glasp pull --archive    # 取得したファイルをアーカイブ
 
 ### PKCE
 
-OAuth2 認可コードの横取り攻撃を防ぐ PKCE（RFC 7636）をオプトインで有効化できます：
+OAuth2 PKCE（RFC 7636）をオプトインで有効化して、認可コードの横取り攻撃を防ぐことができます：
 
 ```bash
 glasp login --pkce

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,6 +68,19 @@ Auth source priority:
 2. Project cache (`.glasp/access.json`)
 3. Interactive login flow
 
+### PKCE
+
+Enable PKCE (RFC 7636) to harden the OAuth2 authorization code exchange:
+
+```bash
+glasp login --pkce
+
+# Or via environment variable
+GLASP_USE_PKCE=1 glasp login
+```
+
+PKCE applies only to the interactive `glasp login` flow.
+
 ### Reuse clasp credentials
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,7 @@ Auth source priority:
 
 ### PKCE
 
-Enable PKCE (RFC 7636) to harden the OAuth2 authorization code exchange:
+Enable OAuth2 PKCE (RFC 7636) to protect against authorization code interception attacks:
 
 ```bash
 glasp login --pkce


### PR DESCRIPTION
## Summary

- Add `### PKCE` section to `docs/usage.md` and `docs/ja/usage.md` under Authentication
- Enable `glasp-smoke` workflow to run automatically on push to `main` (in addition to `workflow_dispatch`)

## Test plan

- [ ] Verify PKCE section renders correctly on the documentation site
- [ ] Confirm smoke test workflow triggers on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)