### PR TITLE
refactor: migrate diagnostic logging to log/slog with structured output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,14 @@ All CLI commands are defined in `cmd/glasp/main.go` as a single struct parsed by
 
 Archives live under `.glasp/archive/<scriptId>/<push|pull>/<timestamp>/` with `manifest.json`, `working/`, and (push only) `payload/` + `payloadIndex`.
 
+## Logging
+
+- Diagnostic logs use `log/slog` via the default logger (`slog.Warn(...)` etc.); the handler is configured once in `cmd/glasp/main.go` (`--log-level`/`GLASP_LOG_LEVEL`, `--log-format`/`GLASP_LOG_FORMAT`, output to stderr, default level info)
+- User-facing command output (results, login guidance) uses `fmt.Fprintf` on the injectable `stdout`/`stderr` writers and is never filtered by log level — do not move it to slog
+- Levels: Debug = OAuth flow progress; Info = notifications (file created/converted); Warn = recoverable fallbacks; Error = failures surfaced through logs
+- Never log tokens, authorization codes, or other secrets; log lengths or masked values instead
+- Tests capture logs by swapping the default logger (`slog.SetDefault` with a `TextHandler` writing to a buffer; see `captureLog` in `cmd/glasp/timeout_test.go`)
+
 ## Key Conventions
 
 - Language: Go (latest stable), standard project layout (`cmd/`, `internal/`)

--- a/cmd/glasp/log_test.go
+++ b/cmd/glasp/log_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewLogHandlerLevel(t *testing.T) {
+	tests := []struct {
+		level    string
+		enabled  []slog.Level
+		disabled []slog.Level
+	}{
+		{
+			level:    "debug",
+			enabled:  []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError},
+			disabled: nil,
+		},
+		{
+			level:    "info",
+			enabled:  []slog.Level{slog.LevelInfo, slog.LevelWarn, slog.LevelError},
+			disabled: []slog.Level{slog.LevelDebug},
+		},
+		{
+			level:    "warn",
+			enabled:  []slog.Level{slog.LevelWarn, slog.LevelError},
+			disabled: []slog.Level{slog.LevelDebug, slog.LevelInfo},
+		},
+		{
+			level:    "error",
+			enabled:  []slog.Level{slog.LevelError},
+			disabled: []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn},
+		},
+		{
+			// kong's enum tag rejects unknown values before newLogHandler
+			// runs, but the fallback branch must still behave like info.
+			level:    "unknown",
+			enabled:  []slog.Level{slog.LevelInfo},
+			disabled: []slog.Level{slog.LevelDebug},
+		},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			h := newLogHandler(&bytes.Buffer{}, tt.level, "text")
+			for _, lvl := range tt.enabled {
+				if !h.Enabled(ctx, lvl) {
+					t.Errorf("level %q: expected %v to be enabled", tt.level, lvl)
+				}
+			}
+			for _, lvl := range tt.disabled {
+				if h.Enabled(ctx, lvl) {
+					t.Errorf("level %q: expected %v to be disabled", tt.level, lvl)
+				}
+			}
+		})
+	}
+}
+
+func TestNewLogHandlerFormat(t *testing.T) {
+	t.Run("json emits parseable JSON records", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(newLogHandler(&buf, "info", "json"))
+		logger.Warn("json format check", "key", "value")
+
+		var record map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+			t.Fatalf("expected JSON output, got %q: %v", buf.String(), err)
+		}
+		if record["msg"] != "json format check" || record["key"] != "value" {
+			t.Fatalf("unexpected JSON record: %v", record)
+		}
+	})
+
+	t.Run("text emits key=value records", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(newLogHandler(&buf, "info", "text"))
+		logger.Warn("text format check", "key", "value")
+
+		out := buf.String()
+		if !strings.Contains(out, `msg="text format check"`) || !strings.Contains(out, "key=value") {
+			t.Fatalf("expected text output, got %q", out)
+		}
+		if json.Valid(buf.Bytes()) {
+			t.Fatalf("text format should not be valid JSON: %q", out)
+		}
+	})
+}
+
+// TestDefaultLevelSuppressesDebug pins the migration's main behavior change:
+// debug-level traces (e.g. OAuth flow progress) stay hidden at the default
+// info level.
+func TestDefaultLevelSuppressesDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(newLogHandler(&buf, "info", "text"))
+	logger.Debug("hidden trace")
+	logger.Info("visible notice")
+
+	out := buf.String()
+	if strings.Contains(out, "hidden trace") {
+		t.Fatalf("debug log should be suppressed at info level, got %q", out)
+	}
+	if !strings.Contains(out, "visible notice") {
+		t.Fatalf("info log should be emitted at info level, got %q", out)
+	}
+}

--- a/cmd/glasp/log_test.go
+++ b/cmd/glasp/log_test.go
@@ -39,7 +39,7 @@ func TestNewLogHandlerLevel(t *testing.T) {
 			// kong's enum tag rejects unknown values before newLogHandler
 			// runs, but the fallback branch must still behave like info.
 			level:    "unknown",
-			enabled:  []slog.Level{slog.LevelInfo},
+			enabled:  []slog.Level{slog.LevelInfo, slog.LevelWarn, slog.LevelError},
 			disabled: []slog.Level{slog.LevelDebug},
 		},
 	}

--- a/cmd/glasp/main.go
+++ b/cmd/glasp/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -101,6 +102,8 @@ func (rc *runContext) archiveMeta() runArchiveMeta {
 // CLI is the main command-line interface structure for glasp.
 type CLI struct {
 	Dir              string              `name:"dir" short:"C" env:"GLASP_DIR" help:"Change to this directory before executing any command."`
+	LogLevel         string              `name:"log-level" env:"GLASP_LOG_LEVEL" enum:"debug,info,warn,error" default:"info" help:"Minimum level for diagnostic logs on stderr (debug|info|warn|error)."`
+	LogFormat        string              `name:"log-format" env:"GLASP_LOG_FORMAT" enum:"text,json" default:"text" help:"Diagnostic log format (text|json)."`
 	Timeout          int                 `name:"timeout" env:"GLASP_TIMEOUT" help:"HTTP timeout for Script API requests in seconds. 0 = use .glasp/config.json value or default (180s)."`
 	NoTimeout        bool                `name:"no-timeout" env:"GLASP_NO_TIMEOUT" help:"Disable HTTP timeout for Script API requests (unlimited). Overrides --timeout and .glasp/config.json."`
 	MaxRetries       int                 `name:"max-retries" env:"GLASP_MAX_RETRIES" help:"Max retry attempts for transient Script API failures (5xx/429/network). Applies only to idempotent commands (push, pull, list-deployments, clone). 0 = use .glasp/config.json value or default (3)."`
@@ -136,9 +139,11 @@ func main() {
 	// re-parsing os.Args ourselves. kong.Parse exits the process on a parse
 	// error, so the selection is always valid here.
 	commandName := selectedCommandName(parsed)
+	slog.SetDefault(slog.New(newLogHandler(stderr, cli.LogLevel, cli.LogFormat)))
 	if dir := strings.TrimSpace(cli.Dir); dir != "" {
 		if err := os.Chdir(dir); err != nil {
-			log.Fatalf("Error: failed to change directory to %q: %v", dir, err)
+			fmt.Fprintf(stderr, "Error: failed to change directory to %q: %v\n", dir, err)
+			os.Exit(1)
 		}
 	}
 	// retryableCommands lists the commands that may safely retry transient
@@ -158,8 +163,31 @@ func main() {
 	err := parsed.Run(rc)
 	recordRunHistory(rawArgs, commandName, time.Since(start), err, rc.archiveMeta())
 	if err != nil {
-		log.Fatalf("Error: %v", err)
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
+}
+
+// newLogHandler builds the slog handler for diagnostic logs. User-facing
+// command output stays on the stdout/stderr writers via fmt and is never
+// filtered by the log level.
+func newLogHandler(w io.Writer, level, format string) slog.Handler {
+	var lvl slog.Level
+	switch level {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: lvl}
+	if format == "json" {
+		return slog.NewJSONHandler(w, opts)
+	}
+	return slog.NewTextHandler(w, opts)
 }
 
 // resolveHTTPTimeout returns the HTTP timeout to use for Script API requests.
@@ -177,7 +205,8 @@ func resolveHTTPTimeout(flagSeconds int, noTimeout bool) time.Duration {
 	case flagSeconds < 0:
 		// 0 is the documented "unset" sentinel; a negative value is invalid
 		// input. Warn so a mistaken --timeout/GLASP_TIMEOUT is visible.
-		log.Printf("Warning: --timeout/GLASP_TIMEOUT value %d is negative and ignored; using .glasp/config.json value or default (%s).", flagSeconds, defaultHTTPTimeout)
+		slog.Warn("--timeout/GLASP_TIMEOUT value is negative and ignored; using .glasp/config.json value or default",
+			"value", flagSeconds, "default", defaultHTTPTimeout.String())
 	default:
 		// flagSeconds == 0 is the "unset" case: kong leaves an unset int flag
 		// at its zero value, so 0 cannot mean a real timeout. Fall through to
@@ -192,12 +221,14 @@ func resolveHTTPTimeout(flagSeconds int, noTimeout bool) time.Duration {
 			// malformed/unreadable (a missing file yields a zero-value config).
 			// Warn instead of silently honoring the default so a timeoutSeconds
 			// typo is visible to the user rather than ignored.
-			log.Printf("Warning: failed to load .glasp/config.json; using default timeout (%s): %v", defaultHTTPTimeout, err)
+			slog.Warn("failed to load .glasp/config.json; using default timeout",
+				"default", defaultHTTPTimeout.String(), "error", err)
 		case glaspCfg.TimeoutSeconds > 0:
 			return time.Duration(glaspCfg.TimeoutSeconds) * time.Second
 		case glaspCfg.TimeoutSeconds < 0:
 			// Negative seconds are invalid; warn rather than silently default.
-			log.Printf("Warning: timeoutSeconds in .glasp/config.json is negative (%d) and ignored; using default timeout (%s).", glaspCfg.TimeoutSeconds, defaultHTTPTimeout)
+			slog.Warn("timeoutSeconds in .glasp/config.json is negative and ignored; using default timeout",
+				"value", glaspCfg.TimeoutSeconds, "default", defaultHTTPTimeout.String())
 		}
 	}
 	return defaultHTTPTimeout
@@ -212,7 +243,8 @@ func resolveHTTPRetries(flag int) int {
 	case flag > 0:
 		return flag
 	case flag < 0:
-		log.Printf("Warning: --max-retries/GLASP_MAX_RETRIES value %d is negative and ignored; using .glasp/config.json value or default (%d).", flag, defaultHTTPRetries)
+		slog.Warn("--max-retries/GLASP_MAX_RETRIES value is negative and ignored; using .glasp/config.json value or default",
+			"value", flag, "default", defaultHTTPRetries)
 	default:
 		// flag == 0 is the "unset" case. Fall through to config/default.
 	}
@@ -221,11 +253,13 @@ func resolveHTTPRetries(flag int) int {
 		glaspCfg, err := config.LoadGlaspConfig(projectRoot)
 		switch {
 		case err != nil:
-			log.Printf("Warning: failed to load .glasp/config.json; using default retries (%d): %v", defaultHTTPRetries, err)
+			slog.Warn("failed to load .glasp/config.json; using default retries",
+				"default", defaultHTTPRetries, "error", err)
 		case glaspCfg.MaxRetries > 0:
 			return glaspCfg.MaxRetries
 		case glaspCfg.MaxRetries < 0:
-			log.Printf("Warning: maxRetries in .glasp/config.json is negative (%d) and ignored; using default retries (%d).", glaspCfg.MaxRetries, defaultHTTPRetries)
+			slog.Warn("maxRetries in .glasp/config.json is negative and ignored; using default retries",
+				"value", glaspCfg.MaxRetries, "default", defaultHTTPRetries)
 		}
 	}
 	return defaultHTTPRetries
@@ -253,7 +287,7 @@ func selectedCommandName(ctx *kong.Context) string {
 func recordRunHistory(args []string, commandName string, duration time.Duration, runErr error, archiveMeta runArchiveMeta) {
 	projectRoot, err := config.FindProjectRoot()
 	if err != nil {
-		log.Printf("Warning: failed to resolve project root for history: %v", err)
+		slog.Warn("failed to resolve project root for history", "error", err)
 		return
 	}
 	if projectRoot == "" {
@@ -279,7 +313,7 @@ func recordRunHistory(args []string, commandName string, duration time.Duration,
 		},
 	}
 	if err := history.Append(projectRoot, entry); err != nil {
-		log.Printf("Warning: failed to append history entry: %v", err)
+		slog.Warn("failed to append history entry", "error", err)
 	}
 }
 

--- a/cmd/glasp/timeout_test.go
+++ b/cmd/glasp/timeout_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -142,19 +142,14 @@ func TestResolveHTTPTimeout(t *testing.T) {
 	})
 }
 
-// captureLog redirects the standard logger's output into a buffer for the
-// duration of fn and returns what was written.
+// captureLog redirects the default slog logger's output into a buffer for
+// the duration of fn and returns what was written.
 func captureLog(t *testing.T, fn func()) string {
 	t.Helper()
 	var buf bytes.Buffer
-	origOut := log.Writer()
-	origFlags := log.Flags()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	defer func() {
-		log.SetOutput(origOut)
-		log.SetFlags(origFlags)
-	}()
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(orig)
 	fn()
 	return buf.String()
 }

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -182,6 +182,38 @@ GLASP_NO_RETRIES=1 glasp push
 }
 ```
 
+## ログ
+
+glasp は診断ログ（警告・フォールバック通知・デバッグトレース）を構造化された形式で **stderr** に出力します。コマンドの実行結果（`Pulled project ...` など）は通常の出力であり、これらの設定の影響を受けません。
+
+### オプション
+
+- `--log-level` フラグ / `GLASP_LOG_LEVEL` 環境変数 — 最小レベル: `debug`、`info`（デフォルト）、`warn`、`error`
+- `--log-format` フラグ / `GLASP_LOG_FORMAT` 環境変数 — 出力形式: `text`（デフォルト）または `json`
+
+```bash
+# OAuth フローの進行状況などデバッグトレースを表示
+glasp login --log-level debug
+
+# 機械可読な JSON ログを出力（CI で便利）
+GLASP_LOG_FORMAT=json glasp push
+
+# 警告を抑制しエラーのみ表示
+glasp pull --log-level error
+```
+
+出力例:
+
+```
+# text（デフォルト）
+time=2026-07-09T10:00:00.000+09:00 level=WARN msg="failed to load .glasp/config.json; using default timeout" default=3m0s
+
+# json
+{"time":"2026-07-09T10:00:00+09:00","level":"WARN","msg":"failed to load .glasp/config.json; using default timeout","default":"3m0s"}
+```
+
+> **注意:** OAuth ログインの進行状況メッセージ（state 検証・認可コード受信など）は `debug` レベルで記録され、デフォルトでは表示されません。ブラウザを起動できない場合に開くべき URL など、操作に必須の案内はログレベルに関係なく常に表示されます。
+
 ## 設定
 
 ### .clasp.json

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -181,6 +181,38 @@ You can also set a project-wide value in `.glasp/config.json`:
 }
 ```
 
+## Logging
+
+glasp writes diagnostic logs (warnings, fallback notices, debug traces) to **stderr** in a structured format. Command results (e.g. `Pulled project ...`) are regular output and are not affected by these settings.
+
+### Options
+
+- `--log-level` flag / `GLASP_LOG_LEVEL` environment variable — minimum level: `debug`, `info` (default), `warn`, or `error`
+- `--log-format` flag / `GLASP_LOG_FORMAT` environment variable — output format: `text` (default) or `json`
+
+```bash
+# Show OAuth flow progress and other debug traces
+glasp login --log-level debug
+
+# Emit machine-readable JSON logs (useful in CI)
+GLASP_LOG_FORMAT=json glasp push
+
+# Suppress warnings, show errors only
+glasp pull --log-level error
+```
+
+Example output:
+
+```
+# text (default)
+time=2026-07-09T10:00:00.000+09:00 level=WARN msg="failed to load .glasp/config.json; using default timeout" default=3m0s
+
+# json
+{"time":"2026-07-09T10:00:00+09:00","level":"WARN","msg":"failed to load .glasp/config.json; using default timeout","default":"3m0s"}
+```
+
+> **Note:** OAuth login progress messages (state validation, authorization code receipt) are logged at `debug` level and hidden by default. Essential instructions — such as the URL to open when the browser cannot be launched — are always printed regardless of the log level.
+
 ## Configuration
 
 ### .clasp.json

--- a/internal/auth/login_flow.go
+++ b/internal/auth/login_flow.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -22,8 +22,10 @@ import (
 // and the user can open the printed URL manually.
 func openBrowser(url string) {
 	if err := browser.Start(url); err != nil {
-		log.Printf("Failed to open browser: %v", err)
-		log.Printf("Please manually open your browser and go to: %s", url)
+		slog.Warn("failed to open browser", "error", err)
+		// The user cannot proceed without this URL, so it goes to the
+		// user-facing writer rather than the level-filtered logger.
+		fmt.Fprintf(stdout, "Please manually open your browser and go to: %s\n", url)
 	}
 }
 
@@ -94,7 +96,7 @@ func LoginWithCachePath(ctx context.Context, config *oauth2.Config, cacheFile st
 func clientFromCachedToken(ctx context.Context, config *oauth2.Config, cacheFile string) (client *http.Client, ok bool) {
 	token, _, _, loadErr := loadToken(cacheFile)
 	if loadErr != nil {
-		log.Printf("No cached token found or failed to load: %v", loadErr)
+		slog.Debug("no cached token found or failed to load", "error", loadErr)
 		return nil, false
 	}
 	// config.TokenSource automatically refreshes the token if it's expired
@@ -102,13 +104,13 @@ func clientFromCachedToken(ctx context.Context, config *oauth2.Config, cacheFile
 	tokenSource := config.TokenSource(ctx, token)
 	freshToken, err := tokenSource.Token()
 	if err != nil {
-		log.Printf("Cached token or refresh token is invalid, proceeding with full OAuth flow: %v", err)
+		slog.Debug("cached token or refresh token is invalid; proceeding with full OAuth flow", "error", err)
 		return nil, false
 	}
 	// Save the token back to cache in case it was refreshed.
 	if freshToken.AccessToken != token.AccessToken {
 		if saveErr := saveToken(cacheFile, freshToken); saveErr != nil {
-			log.Printf("Warning: Failed to save refreshed token: %v", saveErr)
+			slog.Warn("failed to save refreshed token", "error", saveErr)
 		}
 	}
 	fmt.Fprintf(stdout, "Using cached or refreshed token from %s\n", cacheFile)
@@ -139,11 +141,11 @@ func startCallbackServer(listener net.Listener, state *oauthState) (*http.Server
 		if err := state.validate(incomingState); err != nil {
 			errmsg := "Invalid state in response."
 			http.Error(w, errmsg, http.StatusBadRequest)
-			log.Println(errmsg)
+			slog.Warn("invalid state in OAuth callback response", "error", err)
 			sendResult(authCodeResult{err: err})
 			return
 		}
-		log.Printf("Valid state token received")
+		slog.Debug("valid state token received")
 		code := r.URL.Query().Get("code")
 		if code == "" {
 			errmsg := "No code in response. "
@@ -151,11 +153,12 @@ func startCallbackServer(listener net.Listener, state *oauthState) (*http.Server
 				errmsg += fmt.Sprintf("Google returned error: %s", errParam)
 			}
 			http.Error(w, errmsg, http.StatusBadRequest)
-			log.Println(errmsg)
+			slog.Warn("no authorization code in OAuth callback response",
+				"google_error", r.URL.Query().Get("error"))
 			sendResult(authCodeResult{err: fmt.Errorf("%s", errmsg)})
 			return
 		}
-		log.Printf("Received authorization code (length: %d)", len(code))
+		slog.Debug("received authorization code", "length", len(code))
 		fmt.Fprintf(w, "Authentication successful! You can close this tab.")
 		sendResult(authCodeResult{code: code})
 	})
@@ -163,7 +166,7 @@ func startCallbackServer(listener net.Listener, state *oauthState) (*http.Server
 	srv := &http.Server{Handler: mux}
 	go func() {
 		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
-			log.Printf("listen error: %v\n", err)
+			slog.Error("OAuth callback server listen error", "error", err)
 			sendResult(authCodeResult{err: fmt.Errorf("listen: %w", err)})
 		}
 	}()
@@ -210,7 +213,7 @@ func loginWithCachePath(ctx context.Context, config *oauth2.Config, cacheFile st
 		defer cancel()
 		if message, isError := shutdownServerMessage(srv.Shutdown(shutdownCtx)); message != "" {
 			if isError {
-				log.Println(message)
+				slog.Error(message)
 			} else {
 				fmt.Fprintln(stdout, message)
 			}

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -129,12 +129,13 @@ func buildClientFromPayload(ctx context.Context, payload *authFilePayload, sourc
 			if strings.TrimSpace(token.AccessToken) == "" {
 				return nil, fmt.Errorf("failed to refresh token from %s: %w", source, refreshErr)
 			}
-			log.Printf("Warning: failed to refresh token from %s, falling back to token.access_token: %v", source, refreshErr)
+			slog.Warn("failed to refresh token; falling back to token.access_token",
+				"source", source, "error", refreshErr)
 		} else {
 			token = mergeRefreshedToken(token, refreshed)
 			if persistPath != "" {
 				if err := persistAuthToken(persistPath, token); err != nil {
-					log.Printf("Warning: failed to persist refreshed token to %s: %v", persistPath, err)
+					slog.Warn("failed to persist refreshed token", "path", persistPath, "error", err)
 				}
 			}
 		}

--- a/internal/auth/token_store.go
+++ b/internal/auth/token_store.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,7 +163,7 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 	p.mu.Unlock()
 
 	if err := persistAuthToken(p.authPath, token); err != nil {
-		log.Printf("Warning: failed to persist refreshed token to %s: %v", p.authPath, err)
+		slog.Warn("failed to persist refreshed token", "path", p.authPath, "error", err)
 	} else {
 		p.mu.Lock()
 		p.lastSnapshot = snapshot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +108,7 @@ func SaveClaspConfig(dir string, cfg *ClaspConfig) error {
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write %s: %w", filePath, err)
 	} else {
-		log.Printf("Created clasp config file: %s", filePath)
+		slog.Info("created clasp config file", "path", filePath)
 	}
 	return nil
 }

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -2,13 +2,12 @@ package transform
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/takihito/glasp/internal/syncer"
 
@@ -262,8 +261,7 @@ func logConverted(srcPath, outDir, targetPath string) {
 		relTarget = targetPath
 	}
 	relTarget = filepath.ToSlash(relTarget)
-	timestamp := time.Now().Format(time.RFC3339)
-	log.Printf("Converted %s -> %s at %s", srcPath, relTarget, timestamp)
+	slog.Info("converted file", "src", srcPath, "dest", relTarget)
 }
 
 func warnImportExport(localPath, source string) {
@@ -300,7 +298,7 @@ func warnImportExport(localPath, source string) {
 			continue
 		}
 		lineNo := idx + 1
-		log.Printf("Warning: import/export detected in %s:%d", localPath, lineNo)
+		slog.Warn("import/export detected", "file", localPath, "line", lineNo)
 	}
 }
 

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -2,7 +2,7 @@ package transform
 
 import (
 	"bytes"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,18 +132,21 @@ func TestEnsureWithinOutDir(t *testing.T) {
 
 func TestWarnImportExport(t *testing.T) {
 	var buf bytes.Buffer
-	orig := log.Writer()
-	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(orig) })
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(orig) })
 
 	source := "import foo from './foo'\nconst a = 1\nexport function bar() {}\n// export ignored\n"
 	warnImportExport("src/Main.ts", source)
 
 	output := buf.String()
-	if !strings.Contains(output, "src/Main.ts:1") {
+	if !strings.Contains(output, "file=src/Main.ts") {
+		t.Fatalf("expected warning for src/Main.ts, got: %s", output)
+	}
+	if !strings.Contains(output, "line=1") {
 		t.Fatalf("expected warning for line 1, got: %s", output)
 	}
-	if !strings.Contains(output, "src/Main.ts:3") {
+	if !strings.Contains(output, "line=3") {
 		t.Fatalf("expected warning for line 3, got: %s", output)
 	}
 }


### PR DESCRIPTION
## 概要

診断ログを標準 `log` パッケージから `log/slog` に移行し、構造化ログ(text/json)とログレベル制御を導入します。新規依存はありません(標準ライブラリのみ)。

## 変更内容

### ロガー基盤
- グローバルフラグ `--log-level`/`GLASP_LOG_LEVEL`(debug/info/warn/error、デフォルト info)と `--log-format`/`GLASP_LOG_FORMAT`(text/json)を追加。kong の `enum:` タグで不正値を検証
- `cmd/glasp/main.go` で `slog.SetDefault` によりハンドラを一度だけ構築(stderr 出力)

### ログ呼び出しの移行(非テストコード 27箇所・6ファイル)
- Warning 系 → `slog.Warn` + 構造化属性(`value`、`default`、`error` など)
- 通知系(config 作成・ファイル変換)→ `slog.Info`
- OAuth フロー進行状況(state 検証・認可コード受信など)→ `slog.Debug`
- `log.Fatalf` → `fmt.Fprintf(stderr)` + `os.Exit(1)`(`Error: ...` の表示形式を維持)

### ユーザー向け出力の分離
- コマンド実行結果(`Pulled project ...` 等)は従来どおり `fmt.Fprintf` のまま。ログレベルの影響を受けません
- ブラウザ起動失敗時の「手動で URL を開いてください」案内は、ログレベルで抑制されるとログインが進まなくなるため、診断ログではなくユーザー向け writer に移動

### ドキュメント・テスト
- `docs/usage.md` / `docs/ja/usage.md` に Logging セクションを追加
- CLAUDE.md にログ規約(レベル方針・機密情報禁止)を追記
- `newLogHandler` のテーブル駆動テストを追加(レベル解決・フォーマット選択・デフォルトレベルでの Debug 抑制)
- 既存テストのログキャプチャを `log.SetOutput` から `slog.SetDefault` 差し替えに更新

## ⚠️ 挙動変更

1. **診断ログの形式変更**: `Warning: ...` 形式から slog 形式(`time=... level=WARN msg=...`)に変わります。stderr のログをパースしている場合は破壊的変更です
2. **OAuth 進行ログがデフォルト非表示に**: state 検証・認可コード受信などのトレースは `--log-level=debug` で表示されます
3. `--log-level=error` 指定時は Warning も抑制されます

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...` 全パス
- 実バイナリで text/json 出力、レベルフィルタ、kong の enum バリデーションを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)