### PR TITLE
build(deps): bump github/codeql-action init/autobuild/analyze to v4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,14 +45,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- CodeQL requires `init`/`autobuild`/`analyze` to run the same action version, or Autobuild fails with `Loaded a configuration file for version 'X', but running version 'Y'`
- Dependabot PR #124 bumps only `init` to v4.36.3, and #123 bumps only `autobuild` to v4.36.3, each in isolation — merging either alone breaks CI until the other lands
- `upload-sarif` (scorecard.yml) was already bumped to v4.36.3 on main; `analyze` in codeql.yml had not been bumped by any pending PR
- This PR bumps `init`, `autobuild`, and `analyze` together in codeql.yml so all CodeQL action references stay on v4.36.3

## Test plan
- [x] CI (Test, CodeQL, Dependency Review, Socket Security) passes on this PR
- [ ] Close #124 and #123 after merge (superseded by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)