### PR TITLE
fix(ci): fetch full history in tagpr checkout to avoid unauthenticated unshallow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
         env:


### PR DESCRIPTION
## Summary
- The tagpr workflow has failed on every push to main since 2026-07-10 (5 consecutive runs), e.g. https://github.com/takihito/glasp/actions/runs/29154032872/job/86548191911
- tagpr needs full history and tags to compute versions, so it runs `git fetch --unshallow` when the clone is shallow. With `persist-credentials: false`, that fetch has no token and fails with `fatal: could not read Username for 'https://github.com'` (exit 128)
- Adding `fetch-depth: 0` fetches the full history during checkout (which does have credentials), so tagpr never needs to unshallow — and `persist-credentials: false` stays in place

## Impact
- Unblocks tagpr, which has been unable to update the release PR (#117) or create tags since the failures started

## Test plan
- [ ] After merge, verify the tagpr run triggered by the merge push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)