### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/l
 
 ```bash
 brew tap takihito/tap
-brew trust takihito/tap
+brew trust --formula takihito/tap/glasp
 brew install glasp
 ```
 
-> `brew trust` is required because [takihito/tap](https://github.com/takihito/homebrew-tap) is an unsigned tap. Installs a pre-built binary with OAuth credentials embedded.
+> `brew trust` is required because [takihito/tap](https://github.com/takihito/homebrew-tap) is a non-official tap. Installs a pre-built binary with OAuth credentials embedded.
 
 ### go install
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ To change the install directory:
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
 ```
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap takihito/tap
+brew trust takihito/tap
+brew install glasp
+```
+
+> `brew trust` is required because [takihito/tap](https://github.com/takihito/homebrew-tap) is an unsigned tap. Installs a pre-built binary with OAuth credentials embedded.
+
 ### go install
 
 ```bash
@@ -67,7 +77,7 @@ make install  # Build and install globally
 
 | Install method | Credentials |
 |---------------|-------------|
-| Quick Install (pre-built binaries) | Embedded, override with env vars |
+| Quick Install / Homebrew (pre-built binaries) | Embedded, override with env vars |
 | `go install` / source build | Env vars required |
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,6 +34,16 @@ To change the install directory:
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
 ```
 
+## Homebrew (macOS / Linux)
+
+```bash
+brew tap takihito/tap
+brew trust takihito/tap
+brew install glasp
+```
+
+> `brew trust` is required because [takihito/tap](https://github.com/takihito/homebrew-tap) is an unsigned tap. Installs a pre-built binary with OAuth credentials embedded.
+
 ## go install
 
 ```bash
@@ -59,7 +69,7 @@ make install  # Build and install globally
 
 | Install method | Credentials |
 |---------------|-------------|
-| Quick Install (pre-built binaries) | Embedded, override with env vars |
+| Quick Install / Homebrew (pre-built binaries) | Embedded, override with env vars |
 | `go install` / source build | Env vars required |
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,11 +38,11 @@ curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/l
 
 ```bash
 brew tap takihito/tap
-brew trust takihito/tap
+brew trust --formula takihito/tap/glasp
 brew install glasp
 ```
 
-> `brew trust` is required because [takihito/tap](https://github.com/takihito/homebrew-tap) is an unsigned tap. Installs a pre-built binary with OAuth credentials embedded.
+> `brew trust` is required because [takihito/tap](https://github.com/takihito/homebrew-tap) is a non-official tap. Installs a pre-built binary with OAuth credentials embedded.
 
 ## go install
 

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -37,11 +37,11 @@ curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/l
 
 ```bash
 brew tap takihito/tap
-brew trust takihito/tap
+brew trust --formula takihito/tap/glasp
 brew install glasp
 ```
 
-> [takihito/tap](https://github.com/takihito/homebrew-tap) は未署名の tap のため `brew trust` が必要です。ビルド済みバイナリ（OAuth credentials 埋め込み済み）がインストールされます。
+> [takihito/tap](https://github.com/takihito/homebrew-tap) は非公式 tap のため `brew trust` が必要です。ビルド済みバイナリ（OAuth credentials 埋め込み済み）がインストールされます。
 
 ## go install
 

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -33,6 +33,16 @@ export PATH="$HOME/.local/bin:$PATH"
 curl -sSL https://takihito.github.io/glasp/install.sh | GLASP_INSTALL_DIR=/usr/local/bin sh
 ```
 
+## Homebrew（macOS / Linux）
+
+```bash
+brew tap takihito/tap
+brew trust takihito/tap
+brew install glasp
+```
+
+> [takihito/tap](https://github.com/takihito/homebrew-tap) は未署名の tap のため `brew trust` が必要です。ビルド済みバイナリ（OAuth credentials 埋め込み済み）がインストールされます。
+
 ## go install
 
 ```bash
@@ -58,7 +68,7 @@ make install  # グローバルにインストール
 
 | インストール方法 | credentials |
 |-----------------|-------------|
-| クイックインストール（ビルド済みバイナリ） | 埋め込み済み、環境変数で上書き可能 |
+| クイックインストール / Homebrew（ビルド済みバイナリ） | 埋め込み済み、環境変数で上書き可能 |
 | `go install` / ソースビルド | 環境変数で指定が必要 |
 
 ```bash


### PR DESCRIPTION
## Summary
- glasp is now installable via Homebrew from [takihito/homebrew-tap](https://github.com/takihito/homebrew-tap)
- Adds a Homebrew section (`brew tap` → `brew trust --formula` → `brew install glasp`) to README.md, docs/installation.md, and docs/ja/installation.md, placed right after Quick Install
- Notes that `brew trust` is required because the tap is non-official: per [Homebrew's Tap-Trust docs](https://docs.brew.sh/Tap-Trust), trust is required for all non-official taps (there is no tap signing mechanism), and formula-scoped trust is the least-privilege option
- Adds Homebrew to the OAuth credentials table: the formula installs pre-built release binaries, so credentials are embedded and no env vars are needed

## Review notes
- Codex's suggestion to narrow trust to the formula was applied in 848a2da (`brew trust --formula takihito/tap/glasp`)
- Copilot flagged a mismatch between this description (previously said "unsigned tap") and the docs ("non-official tap"). The docs are correct — Homebrew requires trust based on the official/non-official distinction, not signing — so this description has been updated instead

## Test plan
- [x] Verified the formula (Formula/glasp.rb) downloads pre-built release binaries, confirming the credentials-embedded claim
- [ ] Docs render check on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
