### PR TITLE
build(deps): bump github/codeql-action to 4.37.0 and group future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,14 +45,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## 背景

Dependabot が `github/codeql-action` のサブパス（`init` / `autobuild` / `analyze`）をそれぞれ別の依存として扱うため、v4.37.0 への更新が 3 本の PR（#130, #133, #135）に分割されました。

codeql-action は同一ジョブ内の init / autobuild / analyze に同一バージョンを強制するチェックを持つため（github/codeql-action#3100）、各 PR は単体では必ず混在バージョンとなり、`Analyze (go)` ジョブが構造的に失敗します。

- #130（init のみ 4.37.0）: `Loaded a configuration file for version '4.37.0', but running version '4.36.3'`
- #133（autobuild のみ 4.37.0）: `Loaded a configuration file for version '4.36.3', but running version '4.37.0'`
- #135（analyze のみ 4.37.0）: 同上（analyze ステップで失敗）

## 変更内容

1. `codeql.yml` の 3 ステップすべてを v4.37.0（`99df26d4f13ea111d4ec1a7dddef6063f76b97e9`）に一括更新
   - SHA は v4.37.0 タグの実体コミットであることを `git ls-remote` で確認済み（`scorecard.yml` の `upload-sarif` も同 SHA を使用中）
2. `dependabot.yml` に `groups` を追加し、今後の codeql-action 更新が 1 本の PR にまとまるように設定

## マージ後の対応

main が v4.37.0 になれば、Dependabot は #130 / #133 / #135 を自動クローズします（クローズされない場合は手動でクローズしてください）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
