### PR TITLE
fix: accept array-form parentId in .clasp.json for clasp v2 compatibility

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,36 @@ type ClaspConfig struct {
 	Extra     map[string]json.RawMessage `json:"-"`
 }
 
+// UnmarshalJSON accepts both clasp formats for parentId: a plain string
+// (clasp v3) and an array of strings (clasp v2, e.g. ["<driveFileId>"]).
+// When an array is given, the first element is used.
+func (c *ClaspConfig) UnmarshalJSON(data []byte) error {
+	type alias ClaspConfig
+	aux := struct {
+		ParentID json.RawMessage `json:"parentId"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(aux.ParentID) == 0 {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(aux.ParentID, &s); err == nil {
+		c.ParentID = s
+		return nil
+	}
+	var arr []string
+	if err := json.Unmarshal(aux.ParentID, &arr); err == nil {
+		if len(arr) > 0 {
+			c.ParentID = arr[0]
+		}
+		return nil
+	}
+	return fmt.Errorf("parentId must be a string or an array of strings")
+}
+
 // claspConfigFileName is the name of the clasp configuration file.
 const claspConfigFileName = ".clasp.json"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ func (c *ClaspConfig) UnmarshalJSON(data []byte) error {
 	}
 	var arr []string
 	if err := json.Unmarshal(aux.ParentID, &arr); err == nil {
+		c.ParentID = ""
 		if len(arr) > 0 {
 			c.ParentID = arr[0]
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,6 +162,22 @@ func TestLoadClaspConfigParentIDFormats(t *testing.T) {
 	}
 }
 
+func TestClaspConfigUnmarshalReuseResetsParentID(t *testing.T) {
+	var cfg ClaspConfig
+	if err := json.Unmarshal([]byte(`{"scriptId": "sid", "parentId": "parent-1"}`), &cfg); err != nil {
+		t.Fatalf("first unmarshal failed: %v", err)
+	}
+	if cfg.ParentID != "parent-1" {
+		t.Fatalf("Expected ParentID \"parent-1\", got %q", cfg.ParentID)
+	}
+	if err := json.Unmarshal([]byte(`{"scriptId": "sid", "parentId": []}`), &cfg); err != nil {
+		t.Fatalf("second unmarshal failed: %v", err)
+	}
+	if cfg.ParentID != "" {
+		t.Errorf("Expected empty ParentID after unmarshaling empty array into reused struct, got %q", cfg.ParentID)
+	}
+}
+
 func TestClaspConfigPreservesExtraFields(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "glasp_config_extra_test_")
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -123,6 +123,45 @@ func TestClaspIgnore(t *testing.T) {
 	}
 }
 
+func TestLoadClaspConfigParentIDFormats(t *testing.T) {
+	testCases := []struct {
+		name     string
+		raw      string
+		expected string
+		wantErr  bool
+	}{
+		{"string parentId (clasp v3)", `{"scriptId": "sid", "parentId": "parent-123"}`, "parent-123", false},
+		{"array parentId (clasp v2)", `{"scriptId": "sid", "parentId": ["parent-123"]}`, "parent-123", false},
+		{"empty array parentId", `{"scriptId": "sid", "parentId": []}`, "", false},
+		{"missing parentId", `{"scriptId": "sid"}`, "", false},
+		{"invalid parentId type", `{"scriptId": "sid", "parentId": 123}`, "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, ".clasp.json")
+			if err := os.WriteFile(configPath, []byte(tc.raw), 0644); err != nil {
+				t.Fatalf("Failed to write .clasp.json: %v", err)
+			}
+
+			cfg, err := LoadClaspConfig(tmpDir)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadClaspConfig failed: %v", err)
+			}
+			if cfg.ParentID != tc.expected {
+				t.Errorf("Expected ParentID %q, got %q", tc.expected, cfg.ParentID)
+			}
+		})
+	}
+}
+
 func TestClaspConfigPreservesExtraFields(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "glasp_config_extra_test_")
 	if err != nil {


### PR DESCRIPTION
## 概要

旧 clasp (v2) が書き出す配列形式の `parentId`(例: `"parentId": ["<driveFileId>"]`)を含む `.clasp.json` を読み込むと、以下のエラーで失敗する問題を修正します。

```
Error: failed to unmarshal .clasp.json: json: cannot unmarshal array into Go struct field ClaspConfig.parentId of type string
```

## 原因

- clasp v2 は `parentId` を **string の配列** で書き出す
- clasp v3 は **string** で書き出す
- glasp の `ClaspConfig.ParentID` は `string` 固定だったため、v2 形式でパースに失敗していた

## 対応

- `ClaspConfig` にカスタム `UnmarshalJSON` を追加し、両形式を受け付けるようにした
  - 文字列: そのまま使用
  - 配列: 先頭要素を使用(空配列は空文字列)
  - その他の型: 明確なエラーメッセージを返す
- 文字列 / 配列 / 空配列 / 欠落 / 不正型 の5ケースをテストに追加

## テスト

- `go test ./...` 全パス
- 配列形式 `parentId` の `.clasp.json` を持つディレクトリで `glasp open` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
