### PR TITLE
Release for v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.5.1](https://github.com/takihito/glasp/compare/v0.5.0...v0.5.1) - 2026-09-07
+
+- docs: update version references from v0.4.0 to v0.5.0 by @takihito in https://github.com/takihito/glasp/pull/147
+- build(deps): bump the codeql group with 4 updates by @dependabot[bot] in https://github.com/takihito/glasp/pull/150
+- build(deps): bump ossf/scorecard-action from 2.4.3 to 2.4.4 by @dependabot[bot] in https://github.com/takihito/glasp/pull/151
+- build(deps): bump actions/checkout from 7.0.0 to 7.0.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/152
+- build(deps): bump google.golang.org/api from 0.289.0 to 0.291.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/153
+- build(deps): bump google.golang.org/api from 0.291.0 to 0.292.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/154
+- build(deps): bump step-security/harden-runner from 2.20.0 to 2.21.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/159
+- chore: align dependabot codeql-action grouping with field-cage by @takihito in https://github.com/takihito/glasp/pull/161
+- build(deps): bump github.com/alecthomas/kong from 1.16.0 to 1.16.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/157
+- ci: add bullfrog and field-cage egress audit to glasp smoke test by @takihito in https://github.com/takihito/glasp/pull/163
+- fix: allow apt mirrors in harden-runner so Bullfrog's apt install works by @takihito in https://github.com/takihito/glasp/pull/164
+- fix: allow sigstore TUF CDN in harden-runner for cosign verify-blob by @takihito in https://github.com/takihito/glasp/pull/165
+- build(deps): bump google.golang.org/api from 0.292.0 to 0.293.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/158
+- build(deps): bump github.com/evanw/esbuild from 0.28.1 to 0.28.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/160
+- build(deps): bump the codeql-action group across 1 directory with 4 updates by @dependabot[bot] in https://github.com/takihito/glasp/pull/162
+- ci: bump field-cage to v0.1.4 by @takihito in https://github.com/takihito/glasp/pull/166
+- ci: add manual audit-mode and native-firewall variants of glasp smoke workflow by @takihito in https://github.com/takihito/glasp/pull/167
+- build(deps): bump google.golang.org/api from 0.293.0 to 0.294.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/168
+- build(deps): bump the codeql-action group with 4 updates by @dependabot[bot] in https://github.com/takihito/glasp/pull/169
+- build(deps): bump bullfrogsec/bullfrog from 0.11.0 to 0.11.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/171
+- build(deps): bump Songmu/tagpr from 1.20.1 to 1.20.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/170
+
 ## [v0.4.1](https://github.com/takihito/glasp/compare/v0.4.0...v0.4.1) - 2026-07-23
 
 - docs: update commit hash pinning to v0.4.0 by @takihito in https://github.com/takihito/glasp/pull/116

--- a/cmd/glasp/version.go
+++ b/cmd/glasp/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the semantic version. Overridden at build time via ldflags.
-	Version = "v0.5.0"
+	Version = "v0.5.1"
 	// Commit is the git commit hash. Overridden at build time via ldflags.
 	Commit = "none"
 	// Date is the build date. Overridden at build time via ldflags.


### PR DESCRIPTION
This pull request is for the next release as v0.5.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* docs: update version references from v0.4.0 to v0.5.0 by @takihito in https://github.com/takihito/glasp/pull/147
* build(deps): bump the codeql group with 4 updates by @dependabot[bot] in https://github.com/takihito/glasp/pull/150
* build(deps): bump ossf/scorecard-action from 2.4.3 to 2.4.4 by @dependabot[bot] in https://github.com/takihito/glasp/pull/151
* build(deps): bump actions/checkout from 7.0.0 to 7.0.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/152
* build(deps): bump google.golang.org/api from 0.289.0 to 0.291.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/153
* build(deps): bump google.golang.org/api from 0.291.0 to 0.292.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/154
* build(deps): bump step-security/harden-runner from 2.20.0 to 2.21.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/159
* chore: align dependabot codeql-action grouping with field-cage by @takihito in https://github.com/takihito/glasp/pull/161
* build(deps): bump github.com/alecthomas/kong from 1.16.0 to 1.16.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/157
* ci: add bullfrog and field-cage egress audit to glasp smoke test by @takihito in https://github.com/takihito/glasp/pull/163
* fix: allow apt mirrors in harden-runner so Bullfrog's apt install works by @takihito in https://github.com/takihito/glasp/pull/164
* fix: allow sigstore TUF CDN in harden-runner for cosign verify-blob by @takihito in https://github.com/takihito/glasp/pull/165
* build(deps): bump google.golang.org/api from 0.292.0 to 0.293.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/158
* build(deps): bump github.com/evanw/esbuild from 0.28.1 to 0.28.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/160
* build(deps): bump the codeql-action group across 1 directory with 4 updates by @dependabot[bot] in https://github.com/takihito/glasp/pull/162
* ci: bump field-cage to v0.1.4 by @takihito in https://github.com/takihito/glasp/pull/166
* ci: add manual audit-mode and native-firewall variants of glasp smoke workflow by @takihito in https://github.com/takihito/glasp/pull/167
* build(deps): bump google.golang.org/api from 0.293.0 to 0.294.0 by @dependabot[bot] in https://github.com/takihito/glasp/pull/168
* build(deps): bump the codeql-action group with 4 updates by @dependabot[bot] in https://github.com/takihito/glasp/pull/169
* build(deps): bump bullfrogsec/bullfrog from 0.11.0 to 0.11.1 by @dependabot[bot] in https://github.com/takihito/glasp/pull/171
* build(deps): bump Songmu/tagpr from 1.20.1 to 1.20.2 by @dependabot[bot] in https://github.com/takihito/glasp/pull/170


**Full Changelog**: https://github.com/takihito/glasp/compare/v0.5.0...tagpr-from-v0.5.0