### PR TITLE
chore: align dependabot codeql-action grouping with field-cage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,28 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     groups:
-      codeql:
+      # github/codeql-action ships init/analyze/upload-sarif/autobuild as one release;
+      # init writes a config file that analyze checks against its own running
+      # version, so bumping only one of them (as separate per-reference PRs
+      # would) leaves main with a mismatched pair and CodeQL analysis fails:
+      #   "Loaded a configuration file for version 'X', but running version 'Y'"
+      # Group every reference so they always move together in one PR. A group
+      # with no `applies-to` only covers scheduled version updates; security
+      # updates (triggered by an advisory against one of these actions) are a
+      # separate Dependabot mechanism that ignores it unless grouped
+      # explicitly too, so both are declared here.
+      codeql-action:
         patterns:
-          - "github/codeql-action*"
+          - "github/codeql-action/*"
+      codeql-action-security:
+        applies-to: security-updates
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,17 @@ updates:
       # updates (triggered by an advisory against one of these actions) are a
       # separate Dependabot mechanism that ignores it unless grouped
       # explicitly too, so both are declared here.
+      #
+      # When every reference shares a version, Dependabot may identify the
+      # bump under the root name "github/codeql-action" (no sub-path)
+      # instead of a per-action name — the wildcard alone won't match that,
+      # so the exact root name is listed too.
       codeql-action:
         patterns:
+          - "github/codeql-action"
           - "github/codeql-action/*"
       codeql-action-security:
         applies-to: security-updates
         patterns:
+          - "github/codeql-action"
           - "github/codeql-action/*"


### PR DESCRIPTION
## Summary
- `takihito/field-cage` の `.github/dependabot.yml` に合わせて、`github-actions` エコシステムの CodeQL 関連グループ設定を更新
- `github/codeql-action` の pattern を `github/codeql-action/*` に明示化し、security-updates 用のグループ (`codeql-action-security`) を追加
- glasp のワークフローも `github/codeql-action/{init,analyze,autobuild,upload-sarif}` を利用しているため、init/analyze のバージョン不整合による CodeQL 解析失敗を防ぐ目的でグループ化が必要
- `gomod` / `github-actions` 両エコシステムに `open-pull-requests-limit: 5` を追加してPR数を抑制

## Test plan
- [ ] `.github/dependabot.yml` の YAML 構文が正しいこと（GitHub の Dependabot 設定バリデーションで確認）
- [ ] マージ後、Dependabot が `github/codeql-action/*` の更新を単一PRにグループ化することを確認
