### PR TITLE
ci: add bullfrog and field-cage egress audit to glasp smoke test

### DIFF
--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -32,6 +32,21 @@ jobs:
             www.googleapis.com:443
             oauth2.googleapis.com:443
 
+      # Additional egress-monitoring layers, both in audit mode (log-only,
+      # never blocking): they observe the same traffic Harden Runner already
+      # allows/blocks above and give an independent second opinion on what
+      # this job actually calls out to.
+      - name: Bullfrog egress audit
+        uses: bullfrogsec/bullfrog@ebd3ce460ed3371d6fd751649fc1637ef0c21a18 # v0.11.0
+        with:
+          egress-policy: audit
+
+      - name: field-cage egress audit
+        uses: takihito/field-cage@1e55f85545b156b80df517807874c6e0a1361878 # v0.1.2
+        with:
+          version: v0.1.2
+          mode: audit
+
       - name: Verify required secrets are configured
         env:
           _AUTH: ${{ secrets.GLASP_AUTH }}
@@ -76,3 +91,10 @@ jobs:
       - name: glasp push
         working-directory: ${{ steps.workspace.outputs.dir }}
         run: glasp push
+
+      - name: field-cage audit report
+        if: always()
+        uses: takihito/field-cage/report@1e55f85545b156b80df517807874c6e0a1361878 # v0.1.2
+        with:
+          version: v0.1.2
+          fail-on-deny: false


### PR DESCRIPTION
## Summary
- `.github/workflows/glasp-smoke.yml` に `bullfrogsec/bullfrog` と `takihito/field-cage` を audit mode（監視のみ、非ブロック）で追加
- 既存の `step-security/harden-runner`（block mode）はそのまま維持
- ジョブ末尾に `takihito/field-cage/report` を `if: always()` で追加し、観測した通信をジョブサマリー/annotationsとして出力（`fail-on-deny: false`）
- 両アクションはリリースタグのコミットSHAでピン留め

## Test plan
- [ ] `workflow_dispatch` で本ワークフローを実行し、bullfrog・field-cage・harden-runnerが同一ジョブで競合せず正常に動作することを確認する（未検証。harden-runner block modeと2つのaudit modeツールを併用した際のeBPFフック競合の有無は未確認）
- [ ] field-cageのjob summaryに想定される通信先（api.github.com, script.googleapis.com 等）が記録されることを確認する
