### PR TITLE
fix: allow apt mirrors in harden-runner so Bullfrog's apt install works

### DIFF
--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -31,6 +31,13 @@ jobs:
             script.googleapis.com:443
             www.googleapis.com:443
             oauth2.googleapis.com:443
+            azure.archive.ubuntu.com:80
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+          # The three ubuntu.com entries above are for the Bullfrog step below:
+          # it unconditionally apt-get installs libnetfilter-queue-dev and
+          # nftables, which on GitHub-hosted runners resolves through the
+          # regional apt mirror over plain HTTP (port 80).
 
       # Additional egress-monitoring layers, both in audit mode (log-only,
       # never blocking): they observe the same traffic Harden Runner already


### PR DESCRIPTION
## Summary
- `glasp-smoke.yml` の実行が失敗していた原因を修正 (run: https://github.com/takihito/glasp/actions/runs/32711708717)
- `Bullfrog egress audit` ステップは実行時に無条件で `apt-get install libnetfilter-queue-dev nftables` を行うが、GitHub-hosted runner上ではリージョナルなaptミラーへ平文HTTP(port 80)で接続するため、`harden-runner` の `egress-policy: block` にブロックされ `Couldn't install packages` で失敗していた
- その結果 `field-cage egress audit` 以降のステップがスキップされ、末尾の `field-cage audit report`（`if: always()`）も `cosign is not installed` で二次的に失敗していた
- `harden-runner` の `allowed-endpoints` に `azure.archive.ubuntu.com:80` / `archive.ubuntu.com:80` / `security.ubuntu.com:80` を追加して解消

## Test plan
- [ ] `workflow_dispatch` で本ワークフローを実行し、Bullfrog / field-cage / harden-runner が正常に完走することを確認する
