### PR TITLE
fix: allow sigstore TUF CDN in harden-runner for cosign verify-blob

### DIFF
--- a/.github/workflows/glasp-smoke.yml
+++ b/.github/workflows/glasp-smoke.yml
@@ -34,10 +34,16 @@ jobs:
             azure.archive.ubuntu.com:80
             archive.ubuntu.com:80
             security.ubuntu.com:80
+            tuf-repo-cdn.sigstore.dev:443
           # The three ubuntu.com entries above are for the Bullfrog step below:
           # it unconditionally apt-get installs libnetfilter-queue-dev and
           # nftables, which on GitHub-hosted runners resolves through the
           # regional apt mirror over plain HTTP (port 80).
+          #
+          # tuf-repo-cdn.sigstore.dev is for the field-cage step's `cosign
+          # verify-blob` call below: cosign fetches the Sigstore TUF trusted
+          # root from there to verify the bundle format signature, even when
+          # verifying an already-downloaded bundle offline otherwise.
 
       # Additional egress-monitoring layers, both in audit mode (log-only,
       # never blocking): they observe the same traffic Harden Runner already


### PR DESCRIPTION
## Summary
- PR #164 マージ後の再実行 (https://github.com/takihito/glasp/actions/runs/32734687600/job/97454604730) でも `field-cage egress audit` / `field-cage audit report` が失敗していた原因を修正
- field-cage の `action.yml` は `cosign verify-blob` でリリースの署名を検証するが、cosign はその際に Sigstore の TUF trusted root を `tuf-repo-cdn.sigstore.dev` から取得する（バンドルがオフライン検証可能な形式でも、この取得自体は必要）
- この宛先が `harden-runner` の allowlist に無く `connection refused` となり、`trusted root is required when using new bundle format` で失敗していた
- `tuf-repo-cdn.sigstore.dev:443` を `allowed-endpoints` に追加して解消

## Test plan
- [ ] `workflow_dispatch` で再実行し、Bullfrog / field-cage / harden-runner が正常に完走することを確認する
