### PR TITLE
ci: add manual audit-mode and native-firewall variants of glasp smoke workflow

### DIFF
--- a/.github/workflows/glasp-smoke-audit.yml
+++ b/.github/workflows/glasp-smoke-audit.yml
@@ -1,0 +1,110 @@
+name: glasp smoke test (audit)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: glasp-smoke-audit
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      SCRIPT_ID: ${{ secrets.GLASP_SMOKE_SCRIPT_ID }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            script.googleapis.com:443
+            www.googleapis.com:443
+            oauth2.googleapis.com:443
+            azure.archive.ubuntu.com:80
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            tuf-repo-cdn.sigstore.dev:443
+          # The three ubuntu.com entries above are for the Bullfrog step below:
+          # it unconditionally apt-get installs libnetfilter-queue-dev and
+          # nftables, which on GitHub-hosted runners resolves through the
+          # regional apt mirror over plain HTTP (port 80).
+          #
+          # tuf-repo-cdn.sigstore.dev is for the field-cage step's `cosign
+          # verify-blob` call below: cosign fetches the Sigstore TUF trusted
+          # root from there to verify the bundle format signature, even when
+          # verifying an already-downloaded bundle offline otherwise.
+
+      # Additional egress-monitoring layers, both in audit mode (log-only,
+      # never blocking): they observe the same traffic Harden Runner already
+      # observes above and give an independent second opinion on what this
+      # job actually calls out to.
+      - name: Bullfrog egress audit
+        uses: bullfrogsec/bullfrog@ebd3ce460ed3371d6fd751649fc1637ef0c21a18 # v0.11.0
+        with:
+          egress-policy: audit
+
+      - name: field-cage egress audit
+        uses: takihito/field-cage@be622c9843a30bb3bce0be50b545291353af40dd # v0.1.4
+        with:
+          version: v0.1.4
+          mode: audit
+
+      - name: Verify required secrets are configured
+        env:
+          _AUTH: ${{ secrets.GLASP_AUTH }}
+          _SCRIPT_ID: ${{ secrets.GLASP_SMOKE_SCRIPT_ID }}
+        run: |
+          if [ -z "$_AUTH" ]; then
+            echo "::error::GLASP_AUTH must be set as a repository secret."
+            exit 1
+          fi
+          if [ -z "$_SCRIPT_ID" ]; then
+            echo "::error::GLASP_SMOKE_SCRIPT_ID must be set as a repository secret."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install glasp
+        uses: ./
+        with:
+          auth: ${{ secrets.GLASP_AUTH }}
+          client-id: ${{ secrets.GLASP_CLIENT_ID }}
+          client-secret: ${{ secrets.GLASP_CLIENT_SECRET }}
+
+      - name: Prepare workspace
+        id: workspace
+        run: |
+          set -euo pipefail
+          dir="$(mktemp -d "${RUNNER_TEMP}/glasp-smoke.XXXXXX")"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: glasp clone
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp clone "$SCRIPT_ID"
+
+      - name: glasp pull
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp pull
+
+      - name: glasp push
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp push
+
+      - name: field-cage audit report
+        if: always()
+        uses: takihito/field-cage/report@be622c9843a30bb3bce0be50b545291353af40dd # v0.1.4
+        with:
+          version: v0.1.4
+          fail-on-deny: false

--- a/.github/workflows/glasp-smoke-native-firewall.yml
+++ b/.github/workflows/glasp-smoke-native-firewall.yml
@@ -1,0 +1,121 @@
+name: glasp smoke test (native egress firewall)
+
+# Technical preview: exercises GitHub's native egress firewall
+# (https://github.com/github-early-access/actions-native-egress-firewall) by
+# running the smoke job on the `ubuntu-24.04-firewall` runner label. As of
+# writing this only supports audit mode (log-only, no enforcement yet), Linux
+# only, and can occasionally reject a request the destination never saw
+# because the firewall terminates and re-establishes TLS at the egress
+# boundary. Kept workflow_dispatch-only and separate from glasp-smoke.yml /
+# glasp-smoke-audit.yml so a firewall-induced failure never blocks the
+# regular smoke test, and so it can be compared side by side against the
+# harden-runner/bullfrog/field-cage audit layers below.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: glasp-smoke-native-firewall
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-24.04-firewall
+    env:
+      SCRIPT_ID: ${{ secrets.GLASP_SMOKE_SCRIPT_ID }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            script.googleapis.com:443
+            www.googleapis.com:443
+            oauth2.googleapis.com:443
+            azure.archive.ubuntu.com:80
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            tuf-repo-cdn.sigstore.dev:443
+          # The three ubuntu.com entries above are for the Bullfrog step below:
+          # it unconditionally apt-get installs libnetfilter-queue-dev and
+          # nftables, which on GitHub-hosted runners resolves through the
+          # regional apt mirror over plain HTTP (port 80).
+          #
+          # tuf-repo-cdn.sigstore.dev is for the field-cage step's `cosign
+          # verify-blob` call below: cosign fetches the Sigstore TUF trusted
+          # root from there to verify the bundle format signature, even when
+          # verifying an already-downloaded bundle offline otherwise.
+
+      # Additional egress-monitoring layers, both in audit mode (log-only,
+      # never blocking): they observe the same traffic Harden Runner already
+      # observes above and give an independent second opinion on what this
+      # job actually calls out to, alongside the native firewall's own
+      # workflow-summary/artifact logs.
+      - name: Bullfrog egress audit
+        uses: bullfrogsec/bullfrog@ebd3ce460ed3371d6fd751649fc1637ef0c21a18 # v0.11.0
+        with:
+          egress-policy: audit
+
+      - name: field-cage egress audit
+        uses: takihito/field-cage@be622c9843a30bb3bce0be50b545291353af40dd # v0.1.4
+        with:
+          version: v0.1.4
+          mode: audit
+
+      - name: Verify required secrets are configured
+        env:
+          _AUTH: ${{ secrets.GLASP_AUTH }}
+          _SCRIPT_ID: ${{ secrets.GLASP_SMOKE_SCRIPT_ID }}
+        run: |
+          if [ -z "$_AUTH" ]; then
+            echo "::error::GLASP_AUTH must be set as a repository secret."
+            exit 1
+          fi
+          if [ -z "$_SCRIPT_ID" ]; then
+            echo "::error::GLASP_SMOKE_SCRIPT_ID must be set as a repository secret."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install glasp
+        uses: ./
+        with:
+          auth: ${{ secrets.GLASP_AUTH }}
+          client-id: ${{ secrets.GLASP_CLIENT_ID }}
+          client-secret: ${{ secrets.GLASP_CLIENT_SECRET }}
+
+      - name: Prepare workspace
+        id: workspace
+        run: |
+          set -euo pipefail
+          dir="$(mktemp -d "${RUNNER_TEMP}/glasp-smoke.XXXXXX")"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: glasp clone
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp clone "$SCRIPT_ID"
+
+      - name: glasp pull
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp pull
+
+      - name: glasp push
+        working-directory: ${{ steps.workspace.outputs.dir }}
+        run: glasp push
+
+      - name: field-cage audit report
+        if: always()
+        uses: takihito/field-cage/report@be622c9843a30bb3bce0be50b545291353af40dd # v0.1.4
+        with:
+          version: v0.1.4
+          fail-on-deny: false


### PR DESCRIPTION
## Summary
- Add `.github/workflows/glasp-smoke-audit.yml`, a `workflow_dispatch`-only duplicate of `glasp-smoke.yml`
- harden-runner runs in `audit` mode (instead of `block`) so egress can be observed without enforcing
- bullfrog and field-cage remain in `audit` mode, same as the base workflow
- Kept as `workflow_dispatch` only (no `push: main` trigger) to avoid running live `glasp clone/pull/push` against the Google Apps Script project twice on every push
- Add `.github/workflows/glasp-smoke-native-firewall.yml`, a further `workflow_dispatch`-only variant that runs the same smoke job on the `ubuntu-24.04-firewall` runner label to exercise GitHub's native egress firewall technical preview ([github-early-access/actions-native-egress-firewall](https://github.com/github-early-access/actions-native-egress-firewall)) in audit mode, alongside the existing harden-runner/bullfrog/field-cage layers, for side-by-side comparison

## Test plan
- [ ] Manually trigger `glasp-smoke-audit.yml` via `workflow_dispatch` and confirm it completes and harden-runner/bullfrog/field-cage all report audit-mode logs without blocking
- [ ] After merge, manually trigger `glasp-smoke-native-firewall.yml` via `workflow_dispatch` and confirm the `ubuntu-24.04-firewall` runner label is available to this org/repo and the job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
